### PR TITLE
feat: Extender modelo. Soporte para campos, constructores, visibilidad y static

### DIFF
--- a/src/main/java/io/github/philbone/javadocmd/JavadocMd.java
+++ b/src/main/java/io/github/philbone/javadocmd/JavadocMd.java
@@ -51,6 +51,25 @@ public abstract class JavadocMd
 
     /** Directorio base donde se escribirá la documentación generada. */
     private static String outputPath = "/home/felipe/Documentos/proyectos/Java/javadocmd/src/main/java/";
+
+    /**
+     * Contador global de ejecuciones del generador de documentación.
+     */
+    private static int executionCount = 0;
+
+    /** Bandera de depuración para imprimir trazas adicionales. */
+    private static boolean debug = false;
+
+    /**
+     * Constructor protegido por defecto.
+     * <p>
+     * Inicializa valores de configuración básicos.
+     *
+     * @throws IllegalStateException si la configuración inicial es inválida.
+     */
+    protected JavadocMd() throws IllegalStateException {
+        executionCount++;
+    }
     
     /**
      * Método principal que inicia el proceso de generación de documentación.

--- a/src/main/java/io/github/philbone/javadocmd/README.md
+++ b/src/main/java/io/github/philbone/javadocmd/README.md
@@ -1,6 +1,8 @@
 # `io.github.philbone.javadocmd`
 
-## Abstract Class: JavadocMd
+---
+
+## Public Abstract Class <span style="color:#d2691e">JavadocMd</span>
 
 Punto de entrada principal del programa <b>javadoc-md</b>.
 <p>
@@ -15,15 +17,40 @@ Esta clase se encarga de:
 <p>Actualmente soporta la exportación de documentación hacia un archivo <code>README.md</code>
 por cada paquete encontrado en el proyecto.</p>
 
+## 📦 Campos
+
+- #### `private static String outFileName`
+Nombre por defecto del archivo de salida que contendrá la documentación en cada paquete.
+
+- #### `private static String sourcePath`
+Directorio de entrada donde se encuentran las clases a documentar.
+
+- #### `private static String outputPath`
+Directorio base donde se escribirá la documentación generada.
+
+- #### `private static int executionCount`
+Contador global de ejecuciones del generador de documentación.
+
+- #### `private static boolean debug`
+Bandera de depuración para imprimir trazas adicionales.
+
+## 🛠️ Constructores
+
+- #### `protected JavadocMd()`
+Constructor protegido por defecto.
+<p>
+Inicializa valores de configuración básicos.
+
+- *@throws* **IllegalStateException** si la configuración inicial es inválida.
 ## 🧮 Métodos
 
-- #### `void main(String[] args)`
+- #### `public static void main(String[] args)`
 Método principal que inicia el proceso de generación de documentación.
 
 - *@param* **args** argumentos opcionales (no utilizados actualmente).
             Se planea en futuras versiones aceptar <code>sourcePath</code> y <code>outputPath</code>
             como parámetros desde consola.
-- #### `void generateDocs(String sourcePath, String outputPath)`
+- #### `public static void generateDocs(String sourcePath, String outputPath)`
 Genera la documentación en formato Markdown a partir del código fuente de un proyecto Java.
 <p>
 El proceso sigue los siguientes pasos:

--- a/src/main/java/io/github/philbone/javadocmd/exporter/MarkdownBuilder.java
+++ b/src/main/java/io/github/philbone/javadocmd/exporter/MarkdownBuilder.java
@@ -9,7 +9,7 @@ public class MarkdownBuilder
         return this;
     }
 
-    public MarkdownBuilder subtitle(String text) {
+    public MarkdownBuilder subtitle(String text) {        
         sb.append("## ").append(text).append("\n\n");
         return this;
     }

--- a/src/main/java/io/github/philbone/javadocmd/exporter/MarkdownExporter.java
+++ b/src/main/java/io/github/philbone/javadocmd/exporter/MarkdownExporter.java
@@ -2,76 +2,110 @@ package io.github.philbone.javadocmd.exporter;
 
 import io.github.philbone.javadocmd.model.*;
 
-public class MarkdownExporter implements DocExporter
-{
+public class MarkdownExporter implements DocExporter {
 
     @Override
     public String export(DocPackage docPackage) {
         MarkdownBuilder builder = new MarkdownBuilder();
 
-        // Encabezado principal
+        // Encabezado principal        
         builder.title("`" + docPackage.getName() + "`");
 
         // Recorrer clases / interfaces / enums / records
         for (DocClass docClass : docPackage.getClasses()) {
-            builder.subtitle(formatKind(docClass.getKind()) + ": " + docClass.getName());
+            String classVisiblity = docClass.getVisibility().substring(0, 1).toUpperCase() + docClass.getVisibility().substring(1);
+            String classSignature = classVisiblity
+                    + (docClass.isStatic() ? " static " : " ") 
+                    + formatKind(docClass.getKind()) 
+                    + " <span style=\"color:#d2691e\">" + docClass.getName() + "</span>";
+            
+            builder.paragraph("---");
+            builder.subtitle(classSignature.trim());
 
             if (docClass.getDescription() != null && !docClass.getDescription().isEmpty()) {
                 builder.paragraph(docClass.getDescription());
             }
 
-            // Métodos
+            // 📦 Campos
+            if (!docClass.getFields().isEmpty()) {
+                builder.subtitle("📦 Campos");
+                for (DocField field : docClass.getFields()) {
+                    String signature = field.getVisibility()
+                            + (field.isStatic() ? " static" : "")
+                            + " " + field.getType()
+                            + " " + field.getName();
+                    builder.listItem("#### `" + signature.trim() + "`");
+
+                    if (field.getDescription() != null && !field.getDescription().isEmpty()) {
+                        builder.paragraph(field.getDescription());
+                    }
+                }
+            }
+
+            // 🛠️ Constructores
+            if (!docClass.getConstructors().isEmpty()) {
+                builder.subtitle("🛠️ Constructores");
+                for (DocConstructor constructor : docClass.getConstructors()) {
+                    String signature = constructor.getVisibility()
+                            + (constructor.isStatic() ? " static " : " ")
+                            + constructor.getName()
+                            + "(" + String.join(", ", constructor.getParameters()) + ")";
+                    builder.listItem("#### `" + signature.trim() + "`");
+
+                    if (constructor.getDescription() != null && !constructor.getDescription().isEmpty()) {
+                        builder.paragraph(constructor.getDescription());
+                    }
+
+                    for (DocParameter param : constructor.getDocParameters()) {
+                        builder.listItem("*@param* **" + param.getName() + "** " + param.getDescription());
+                    }
+
+                    for (DocException ex : constructor.getExceptions()) {
+                        builder.listItem("*@throws* **" + ex.getName() + "** " + ex.getDescription());
+                    }
+                }
+            }
+
+            // 🧮 Métodos
             if (!docClass.getMethods().isEmpty()) {
                 builder.subtitle("🧮 Métodos");
                 for (DocMethod method : docClass.getMethods()) {
-                    String signature = method.getReturnType() + " " + method.getName()
+                    String signature = method.getVisibility()
+                            + (method.isStatic() ? " static" : "")
+                            + " " + method.getReturnType()
+                            + " " + method.getName()
                             + "(" + String.join(", ", method.getParameters()) + ")";
-                    builder.listItem("#### `" + signature + "`");
+                    builder.listItem("#### `" + signature.trim() + "`");
 
                     if (method.getDescription() != null && !method.getDescription().isEmpty()) {
                         builder.paragraph(method.getDescription());
                     }
 
-                    // @param
                     for (DocParameter param : method.getDocParameters()) {
                         builder.listItem("*@param* **" + param.getName() + "** " + param.getDescription());
                     }
 
-                    // @return
                     if (method.getReturnDescription() != null) {
                         builder.listItem("*@return* " + method.getReturnDescription());
                     }
 
-                    // @throws
                     for (DocException ex : method.getExceptions()) {
                         builder.listItem("*@throws* **" + ex.getName() + "** " + ex.getDescription());
                     }
                 }
             }
-        }
-
+        }        
+        
         return builder.build();
-    }
-
-    private String capitalize(String s) {
-        if (s == null || s.isEmpty()) {
-            return s;
-        }
-        return s.substring(0, 1).toUpperCase() + s.substring(1);
     }
 
     private String formatKind(Kind kind) {
         return switch (kind) {
-            case CLASS ->
-                "Class";
-            case ABSTRACT_CLASS ->
-                "Abstract Class";
-            case INTERFACE ->
-                "Interface";
-            case ENUM ->
-                "Enum";
-            case RECORD ->
-                "Record";
+            case CLASS -> "Class";
+            case ABSTRACT_CLASS -> "Abstract Class";
+            case INTERFACE -> "Interface";
+            case ENUM -> "Enum";
+            case RECORD -> "Record";
         };
     }
 }

--- a/src/main/java/io/github/philbone/javadocmd/exporter/README.md
+++ b/src/main/java/io/github/philbone/javadocmd/exporter/README.md
@@ -1,16 +1,23 @@
 # `io.github.philbone.javadocmd.exporter`
 
-## Interface: DocExporter
+---
+
+## Public Interface <span style="color:#d2691e">DocExporter</span>
 
 ## 🧮 Métodos
 
-- #### `String export(DocPackage docPackage)`
-## Class: MarkdownBuilder
+- #### `package-private String export(DocPackage docPackage)`
+---
 
+## Public Class <span style="color:#d2691e">MarkdownBuilder</span>
+
+## 📦 Campos
+
+- #### `private StringBuilder sb`
 ## 🧮 Métodos
 
-- #### `MarkdownBuilder title(String text)`
-- #### `MarkdownBuilder subtitle(String text)`
-- #### `MarkdownBuilder paragraph(String text)`
-- #### `MarkdownBuilder listItem(String text)`
-- #### `String build()`
+- #### `public MarkdownBuilder title(String text)`
+- #### `public MarkdownBuilder subtitle(String text)`
+- #### `public MarkdownBuilder paragraph(String text)`
+- #### `public MarkdownBuilder listItem(String text)`
+- #### `public String build()`

--- a/src/main/java/io/github/philbone/javadocmd/extractor/JavadocExtractorVisitor.java
+++ b/src/main/java/io/github/philbone/javadocmd/extractor/JavadocExtractorVisitor.java
@@ -1,9 +1,8 @@
 package io.github.philbone.javadocmd.extractor;
 
-import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
-import com.github.javaparser.ast.body.EnumDeclaration;
-import com.github.javaparser.ast.body.MethodDeclaration;
-import com.github.javaparser.ast.body.RecordDeclaration;
+import com.github.javaparser.ast.Modifier;
+import com.github.javaparser.ast.nodeTypes.NodeWithModifiers;
+import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.visitor.VoidVisitorAdapter;
 import com.github.javaparser.javadoc.Javadoc;
 import com.github.javaparser.ast.comments.JavadocComment;
@@ -13,84 +12,76 @@ import java.util.Optional;
 import java.util.ArrayList;
 import java.util.List;
 
-public class JavadocExtractorVisitor extends VoidVisitorAdapter<DocPackage>
-{
+public class JavadocExtractorVisitor extends VoidVisitorAdapter<DocPackage> {
 
     @Override
     public void visit(ClassOrInterfaceDeclaration n, DocPackage docPackage) {
         super.visit(n, docPackage);
 
-        String description = n.getComment()
-                .filter(c -> c instanceof JavadocComment)
-                .map(c -> ((JavadocComment) c).parse().getDescription().toText())
-                .orElse("");
+        String description = extractDescription(n);
+        Kind kind = n.isInterface()
+                ? Kind.INTERFACE
+                : (n.isAbstract() ? Kind.ABSTRACT_CLASS : Kind.CLASS);
 
-        Kind kind;
-        if (n.isInterface()) {
-            kind = Kind.INTERFACE;
-        } else if (n.isAbstract()) {
-            kind = Kind.ABSTRACT_CLASS;
-        } else {
-            kind = Kind.CLASS;
-        }
+        String visibility = extractVisibility(n);
+        boolean isStatic = extractIsStatic(n);
 
-        DocClass docClass = new DocClass(n.getNameAsString(), description, kind);
+        DocClass docClass = new DocClass(n.getNameAsString(), description, kind, visibility, isStatic);
         docPackage.addClass(docClass);
 
+        // métodos, constructores y campos
         n.getMethods().forEach(m -> visitMethod(m, docClass));
+        n.getConstructors().forEach(c -> visitConstructor(c, docClass));
+        n.getFields().forEach(f -> visitField(f, docClass));
     }
 
     @Override
     public void visit(EnumDeclaration n, DocPackage docPackage) {
         super.visit(n, docPackage);
 
-        String description = n.getComment()
-                .filter(c -> c instanceof JavadocComment)
-                .map(c -> ((JavadocComment) c).parse().getDescription().toText())
-                .orElse("");
+        String description = extractDescription(n);
+        String visibility = extractVisibility(n);
+        boolean isStatic = extractIsStatic(n);
 
-        DocClass docClass = new DocClass(n.getNameAsString(), description, Kind.ENUM);
+        DocClass docClass = new DocClass(n.getNameAsString(), description, Kind.ENUM, visibility, isStatic);
         docPackage.addClass(docClass);
 
-        n.getMembers().stream()
-                .filter(m -> m instanceof MethodDeclaration)
-                .map(m -> (MethodDeclaration) m)
-                .forEach(m -> visitMethod(m, docClass));
+        n.getMembers().forEach(m -> {
+            if (m instanceof MethodDeclaration method) visitMethod(method, docClass);
+            if (m instanceof ConstructorDeclaration cons) visitConstructor(cons, docClass);
+            if (m instanceof FieldDeclaration field) visitField(field, docClass);
+        });
     }
 
     @Override
     public void visit(RecordDeclaration n, DocPackage docPackage) {
         super.visit(n, docPackage);
 
-        String description = n.getComment()
-                .filter(c -> c instanceof JavadocComment)
-                .map(c -> ((JavadocComment) c).parse().getDescription().toText())
-                .orElse("");
+        String description = extractDescription(n);
+        String visibility = extractVisibility(n);
+        boolean isStatic = extractIsStatic(n);
 
-        DocClass docClass = new DocClass(n.getNameAsString(), description, Kind.RECORD);
+        DocClass docClass = new DocClass(n.getNameAsString(), description, Kind.RECORD, visibility, isStatic);
         docPackage.addClass(docClass);
 
-        n.getMembers().stream()
-                .filter(m -> m instanceof MethodDeclaration)
-                .map(m -> (MethodDeclaration) m)
-                .forEach(m -> visitMethod(m, docClass));
+        n.getMembers().forEach(m -> {
+            if (m instanceof MethodDeclaration method) visitMethod(method, docClass);
+            if (m instanceof ConstructorDeclaration cons) visitConstructor(cons, docClass);
+            if (m instanceof FieldDeclaration field) visitField(field, docClass);
+        });
     }
 
+    // ---------- Métodos privados ---------- //
     private void visitMethod(MethodDeclaration n, DocClass docClass) {
         String description = "";
         List<DocParameter> docParams = new ArrayList<>();
         String returnDescription = null;
         List<DocException> exceptions = new ArrayList<>();
 
-        Optional<JavadocComment> javadocComment = n.getComment()
-                .filter(c -> c instanceof JavadocComment)
-                .map(c -> (JavadocComment) c);
+        Javadoc javadoc = extractJavadoc(n);
 
-        if (javadocComment.isPresent()) {
-            Javadoc javadoc = javadocComment.get().parse();
+        if (javadoc != null) {
             description = javadoc.getDescription().toText();
-
-            // Procesar etiquetas con for clásico (más flexible a futuro)
             for (var tag : javadoc.getBlockTags()) {
                 switch (tag.getType()) {
                     case PARAM -> {
@@ -98,39 +89,139 @@ public class JavadocExtractorVisitor extends VoidVisitorAdapter<DocPackage>
                         String paramDesc = tag.getContent().toText();
                         docParams.add(new DocParameter(paramName, paramDesc));
                     }
-                    case RETURN -> {
-                        returnDescription = tag.getContent().toText();
+                    case RETURN -> returnDescription = tag.getContent().toText();
+                    case THROWS, EXCEPTION -> {
+                        String excName = tag.getName().orElse("Exception");
+                        String excDesc = tag.getContent().toText();
+                        exceptions.add(new DocException(excName, excDesc));
+                    }
+                    default -> {}
+                }
+            }
+        }
+
+        String visibility = extractVisibility(n);
+        boolean isStatic = extractIsStatic(n);
+
+        DocMethod docMethod = new DocMethod(
+                n.getNameAsString(),
+                n.getType().toString(),
+                n.getParameters().stream().map(p -> p.getType() + " " + p.getName()).toList(),
+                description,
+                visibility,
+                isStatic
+        );
+
+        docParams.forEach(docMethod::addDocParameter);
+        if (returnDescription != null) docMethod.setReturnDescription(returnDescription);
+        exceptions.forEach(docMethod::addException);
+
+        docClass.addMethod(docMethod);
+    }
+
+    private void visitConstructor(ConstructorDeclaration n, DocClass docClass) {
+        String description = "";
+        List<DocParameter> docParams = new ArrayList<>();
+        List<DocException> exceptions = new ArrayList<>();
+
+        Javadoc javadoc = extractJavadoc(n);
+        if (javadoc != null) {
+            description = javadoc.getDescription().toText();
+            for (var tag : javadoc.getBlockTags()) {
+                switch (tag.getType()) {
+                    case PARAM -> {
+                        String paramName = tag.getName().orElse("unnamed");
+                        String paramDesc = tag.getContent().toText();
+                        docParams.add(new DocParameter(paramName, paramDesc));
                     }
                     case THROWS, EXCEPTION -> {
                         String excName = tag.getName().orElse("Exception");
                         String excDesc = tag.getContent().toText();
                         exceptions.add(new DocException(excName, excDesc));
                     }
-                    default -> {
-                        // otras etiquetas se manejarán más adelante
-                    }
+                    default -> {}
                 }
             }
         }
 
-        // Crear DocMethod con la info básica
-        DocMethod docMethod = new DocMethod(
+        List<String> params = n.getParameters().stream()
+                .map(p -> p.getType().asString() + " " + p.getNameAsString())
+                .toList();
+
+        String visibility = extractVisibility(n);
+        boolean isStatic = extractIsStatic(n); // constructors normally are not static, but consistent API
+
+        DocConstructor docConstructor = new DocConstructor(
                 n.getNameAsString(),
-                n.getType().toString(),
-                n.getParameters().stream()
-                        .map(p -> p.getType() + " " + p.getName())
-                        .toList(),
-                description
+                params,
+                description,
+                visibility,
+                isStatic
         );
 
-        // Agregar detalles documentados
-        docParams.forEach(docMethod::addDocParameter);
-        if (returnDescription != null) {
-            docMethod.setReturnDescription(returnDescription);
-        }
-        exceptions.forEach(docMethod::addException);
+        docParams.forEach(docConstructor::addDocParameter);
+        exceptions.forEach(docConstructor::addException);
 
-        docClass.addMethod(docMethod);
+        docClass.addConstructor(docConstructor);
     }
 
+    private void visitField(FieldDeclaration n, DocClass docClass) {
+        String description = extractDescription(n);
+        String visibility = extractVisibility(n);
+        boolean isStatic = extractIsStatic(n);
+
+        n.getVariables().forEach(var -> {
+            DocField docField = new DocField(
+                    var.getNameAsString(),
+                    n.getElementType().toString(),
+                    description,
+                    visibility,
+                    isStatic
+            );
+            docClass.addField(docField);
+        });
+    }
+
+    // ---------- Utilidades ---------- //
+    private String extractDescription(BodyDeclaration<?> n) {
+        return n.getComment()
+                .filter(c -> c instanceof JavadocComment)
+                .map(c -> ((JavadocComment) c).parse().getDescription().toText())
+                .orElse("");
+    }
+
+    private Javadoc extractJavadoc(BodyDeclaration<?> n) {
+        Optional<JavadocComment> javadocComment = n.getComment()
+                .filter(c -> c instanceof JavadocComment)
+                .map(JavadocComment.class::cast);
+        return javadocComment.map(JavadocComment::parse).orElse(null);
+    }
+
+    /**
+     * 
+     * @param n
+     * @return String la visibilidad del nodo. En nodos que no implementen NodeWithModifiers (casos raros), devuelve "package-private"
+     */
+    private String extractVisibility(BodyDeclaration<?> n) {
+        if (n instanceof NodeWithModifiers<?>) {
+            NodeWithModifiers<?> withMods = (NodeWithModifiers<?>) n;
+            if (withMods.hasModifier(Modifier.Keyword.PUBLIC)) return "public";
+            if (withMods.hasModifier(Modifier.Keyword.PROTECTED)) return "protected";
+            if (withMods.hasModifier(Modifier.Keyword.PRIVATE)) return "private";
+        }
+        return "package-private";
+    }
+    
+    /**
+     * 
+     * @param n
+     * @return boolean En nodos que no implementen NodeWithModifiers (casos raros), devuelve false para static
+     */
+    private boolean extractIsStatic(BodyDeclaration<?> n) {
+        if (n instanceof NodeWithModifiers<?>) {
+            NodeWithModifiers<?> withMods = (NodeWithModifiers<?>) n;
+            return withMods.hasModifier(Modifier.Keyword.STATIC);
+        }
+        return false;
+    }
 }

--- a/src/main/java/io/github/philbone/javadocmd/model/DocClass.java
+++ b/src/main/java/io/github/philbone/javadocmd/model/DocClass.java
@@ -3,23 +3,37 @@ package io.github.philbone.javadocmd.model;
 import java.util.ArrayList;
 import java.util.List;
 
-public class DocClass
-{
-    private String name;
-    private String description;
-    private Kind kind;
-    private List<DocMethod> methods = new ArrayList<>();
+public class DocClass {
+    private final String name;
+    private final String description;
+    private final Kind kind;
+    private final String visibility;
+    private final boolean isStatic;
 
-    public DocClass(String name, String description, Kind kind) {
+    private final List<DocField> fields = new ArrayList<>();
+    private final List<DocConstructor> constructors = new ArrayList<>();
+    private final List<DocMethod> methods = new ArrayList<>();
+
+    public DocClass(String name, String description, Kind kind, String visibility, boolean isStatic) {
         this.name = name;
         this.description = description;
         this.kind = kind;
+        this.visibility = visibility;
+        this.isStatic = isStatic;
     }
 
     public String getName() { return name; }
     public String getDescription() { return description; }
     public Kind getKind() { return kind; }
+    public String getVisibility() { return visibility; }
+    public boolean isStatic() { return isStatic; }
 
-    public List<DocMethod> getMethods() { return methods; }
+    public void addField(DocField field) { fields.add(field); }
+    public List<DocField> getFields() { return fields; }
+
+    public void addConstructor(DocConstructor constructor) { constructors.add(constructor); }
+    public List<DocConstructor> getConstructors() { return constructors; }
+
     public void addMethod(DocMethod method) { methods.add(method); }
+    public List<DocMethod> getMethods() { return methods; }
 }

--- a/src/main/java/io/github/philbone/javadocmd/model/DocConstructor.java
+++ b/src/main/java/io/github/philbone/javadocmd/model/DocConstructor.java
@@ -3,21 +3,21 @@ package io.github.philbone.javadocmd.model;
 import java.util.ArrayList;
 import java.util.List;
 
-public class DocMethod 
+/**
+ * Representa un constructor documentado dentro de una clase.
+ */
+public class DocConstructor 
 {
     private final String name;
-    private final String returnType;
     private final List<String> parameters;
     private final String description;
     private final String visibility;
-    private final boolean isStatic;
-    private String returnDescription;
+    private final boolean isStatic; // casi siempre false, pero lo dejamos para consistencia
     private final List<DocParameter> docParameters = new ArrayList<>();
     private final List<DocException> exceptions = new ArrayList<>();
 
-    public DocMethod(String name, String returnType, List<String> parameters, String description, String visibility, boolean isStatic) {
+    public DocConstructor(String name, List<String> parameters, String description, String visibility, boolean isStatic) {
         this.name = name;
-        this.returnType = returnType;
         this.parameters = parameters;
         this.description = description;
         this.visibility = visibility;
@@ -25,14 +25,10 @@ public class DocMethod
     }
 
     public String getName() { return name; }
-    public String getReturnType() { return returnType; }
     public List<String> getParameters() { return parameters; }
     public String getDescription() { return description; }
     public String getVisibility() { return visibility; }
     public boolean isStatic() { return isStatic; }
-
-    public void setReturnDescription(String returnDescription) { this.returnDescription = returnDescription; }
-    public String getReturnDescription() { return returnDescription; }
 
     public void addDocParameter(DocParameter param) { docParameters.add(param); }
     public List<DocParameter> getDocParameters() { return docParameters; }

--- a/src/main/java/io/github/philbone/javadocmd/model/DocField.java
+++ b/src/main/java/io/github/philbone/javadocmd/model/DocField.java
@@ -1,0 +1,27 @@
+package io.github.philbone.javadocmd.model;
+
+/**
+ * Representa un campo (atributo) documentado dentro de una clase.
+ */
+public class DocField 
+{
+    private final String name;
+    private final String type;
+    private final String description;
+    private final String visibility;
+    private final boolean isStatic;
+
+    public DocField(String name, String type, String description, String visibility, boolean isStatic) {
+        this.name = name;
+        this.type = type;
+        this.description = description;
+        this.visibility = visibility;
+        this.isStatic = isStatic;
+    }
+
+    public String getName() { return name; }
+    public String getType() { return type; }
+    public String getDescription() { return description; }
+    public String getVisibility() { return visibility; }
+    public boolean isStatic() { return isStatic; }
+}

--- a/src/main/java/io/github/philbone/javadocmd/model/README.md
+++ b/src/main/java/io/github/philbone/javadocmd/model/README.md
@@ -1,46 +1,166 @@
 # `io.github.philbone.javadocmd.model`
 
-## Class: DocClass
+---
 
+## Public Class <span style="color:#d2691e">DocConstructor</span>
+
+Representa un constructor documentado dentro de una clase.
+
+## 📦 Campos
+
+- #### `private String name`
+- #### `private List<String> parameters`
+- #### `private String description`
+- #### `private String visibility`
+- #### `private boolean isStatic`
+- #### `private List<DocParameter> docParameters`
+- #### `private List<DocException> exceptions`
+## 🛠️ Constructores
+
+- #### `public DocConstructor(String name, List<String> parameters, String description, String visibility, boolean isStatic)`
 ## 🧮 Métodos
 
-- #### `String getName()`
-- #### `String getDescription()`
-- #### `Kind getKind()`
-- #### `List<DocMethod> getMethods()`
-- #### `void addMethod(DocMethod method)`
-## Class: DocMethod
+- #### `public String getName()`
+- #### `public List<String> getParameters()`
+- #### `public String getDescription()`
+- #### `public String getVisibility()`
+- #### `public boolean isStatic()`
+- #### `public void addDocParameter(DocParameter param)`
+- #### `public List<DocParameter> getDocParameters()`
+- #### `public void addException(DocException exception)`
+- #### `public List<DocException> getExceptions()`
+---
 
+## Public Class <span style="color:#d2691e">DocClass</span>
+
+## 📦 Campos
+
+- #### `private String name`
+- #### `private String description`
+- #### `private Kind kind`
+- #### `private String visibility`
+- #### `private boolean isStatic`
+- #### `private List<DocField> fields`
+- #### `private List<DocConstructor> constructors`
+- #### `private List<DocMethod> methods`
+## 🛠️ Constructores
+
+- #### `public DocClass(String name, String description, Kind kind, String visibility, boolean isStatic)`
 ## 🧮 Métodos
 
-- #### `String getName()`
-- #### `String getReturnType()`
-- #### `List<String> getParameters()`
-- #### `String getDescription()`
-- #### `List<DocParameter> getDocParameters()`
-- #### `void addDocParameter(DocParameter param)`
-- #### `String getReturnDescription()`
-- #### `void setReturnDescription(String returnDescription)`
-- #### `List<DocException> getExceptions()`
-- #### `void addException(DocException exception)`
-## Class: DocParameter
+- #### `public String getName()`
+- #### `public String getDescription()`
+- #### `public Kind getKind()`
+- #### `public String getVisibility()`
+- #### `public boolean isStatic()`
+- #### `public void addField(DocField field)`
+- #### `public List<DocField> getFields()`
+- #### `public void addConstructor(DocConstructor constructor)`
+- #### `public List<DocConstructor> getConstructors()`
+- #### `public void addMethod(DocMethod method)`
+- #### `public List<DocMethod> getMethods()`
+---
 
+## Public Class <span style="color:#d2691e">DocMethod</span>
+
+## 📦 Campos
+
+- #### `private String name`
+- #### `private String returnType`
+- #### `private List<String> parameters`
+- #### `private String description`
+- #### `private String visibility`
+- #### `private boolean isStatic`
+- #### `private String returnDescription`
+- #### `private List<DocParameter> docParameters`
+- #### `private List<DocException> exceptions`
+## 🛠️ Constructores
+
+- #### `public DocMethod(String name, String returnType, List<String> parameters, String description, String visibility, boolean isStatic)`
 ## 🧮 Métodos
 
-- #### `String getName()`
-- #### `String getDescription()`
-## Class: DocPackage
+- #### `public String getName()`
+- #### `public String getReturnType()`
+- #### `public List<String> getParameters()`
+- #### `public String getDescription()`
+- #### `public String getVisibility()`
+- #### `public boolean isStatic()`
+- #### `public void setReturnDescription(String returnDescription)`
+- #### `public String getReturnDescription()`
+- #### `public void addDocParameter(DocParameter param)`
+- #### `public List<DocParameter> getDocParameters()`
+- #### `public void addException(DocException exception)`
+- #### `public List<DocException> getExceptions()`
+---
 
+## Public Class <span style="color:#d2691e">DocParameter</span>
+
+## 📦 Campos
+
+- #### `private String name`
+- #### `private String description`
+## 🛠️ Constructores
+
+- #### `public DocParameter(String name, String description)`
 ## 🧮 Métodos
 
-- #### `String getName()`
-- #### `List<DocClass> getClasses()`
-- #### `void addClass(DocClass docClass)`
-## Enum: Kind
+- #### `public String getName()`
+- #### `public String getDescription()`
+---
 
-## Class: DocException
+## Public Class <span style="color:#d2691e">DocPackage</span>
 
+## 📦 Campos
+
+- #### `private String name`
+- #### `private List<DocClass> classes`
+## 🛠️ Constructores
+
+- #### `public DocPackage(String name)`
 ## 🧮 Métodos
 
-- #### `String getName()`
-- #### `String getDescription()`
+- #### `public String getName()`
+- #### `public List<DocClass> getClasses()`
+- #### `public void addClass(DocClass docClass)`
+---
+
+## Public Enum <span style="color:#d2691e">Kind</span>
+
+---
+
+## Public Class <span style="color:#d2691e">DocException</span>
+
+## 📦 Campos
+
+- #### `private String name`
+- #### `private String description`
+## 🛠️ Constructores
+
+- #### `public DocException(String name, String description)`
+## 🧮 Métodos
+
+- #### `public String getName()`
+- #### `public String getDescription()`
+---
+
+## Public Class <span style="color:#d2691e">DocField</span>
+
+Representa un campo (atributo) documentado dentro de una clase.
+
+## 📦 Campos
+
+- #### `private String name`
+- #### `private String type`
+- #### `private String description`
+- #### `private String visibility`
+- #### `private boolean isStatic`
+## 🛠️ Constructores
+
+- #### `public DocField(String name, String type, String description, String visibility, boolean isStatic)`
+## 🧮 Métodos
+
+- #### `public String getName()`
+- #### `public String getType()`
+- #### `public String getDescription()`
+- #### `public String getVisibility()`
+- #### `public boolean isStatic()`


### PR DESCRIPTION
- [x] Modelo extendido (DocField, DocConstructor, visibilidad, static).
- [x] Visitor actualizado (extrae visibility + static en clases, campos, constructores y métodos).
- [x] MarkdownExporter que ya muestra todo, con tu toque de diseño en la firma de clase.
- [x] Probado sobre JavadocMd y confirmamos que salen campos estáticos, constructores protegidos y métodos.