### PR TITLE
feat(docs): agregar soporte para título de proyecto mediante @project…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target/
+/nbproject/

--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -28,6 +28,56 @@
       </plugin>
     </plugins>
   </build>
+  <dependencies>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>5.6.0</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <artifactId>apiguardian-api</artifactId>
+          <groupId>org.apiguardian</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>opentest4j</artifactId>
+          <groupId>org.opentest4j</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>junit-platform-commons</artifactId>
+          <groupId>org.junit.platform</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <version>5.6.0</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <artifactId>apiguardian-api</artifactId>
+          <groupId>org.apiguardian</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>5.6.0</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <artifactId>junit-platform-engine</artifactId>
+          <groupId>org.junit.platform</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>apiguardian-api</artifactId>
+          <groupId>org.apiguardian</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
   <properties>
     <maven.compiler.target>21</maven.compiler.target>
     <maven.compiler.source>21</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,24 @@
             <artifactId>javaparser-core</artifactId>
             <version>3.27.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.6.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>5.6.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.6.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/io/github/philbone/javadocmd/JavadocMd.java
+++ b/src/main/java/io/github/philbone/javadocmd/JavadocMd.java
@@ -43,6 +43,9 @@ import java.util.*;
  * <p>
  * Actualmente soporta la exportación de documentación hacia un archivo
  * <code>README.md</code> por cada paquete encontrado en el proyecto.</p>
+ * 
+ * @author Felipe M
+ * @project JavadocMd
  */
 public abstract class JavadocMd
 {
@@ -55,6 +58,7 @@ public abstract class JavadocMd
 
     /**
      * Directorio de entrada donde se encuentran las clases a documentar.
+     * @author Felipe M.
      */
     private static String sourcePath = "/home/felipe/Documentos/proyectos/Java/javadocmd/src/main/java/io/github/philbone/javadocmd/";
 

--- a/src/main/java/io/github/philbone/javadocmd/README.md
+++ b/src/main/java/io/github/philbone/javadocmd/README.md
@@ -1,6 +1,10 @@
-# `io.github.philbone.javadocmd`
+# JavadocMd
 
-## Resumen de Clases
+## io.github.philbone.javadocmd
+
+### Resumen de Clases
+
+
 |CLASE|DESCRIPCIÓN|
 |---|---|
 |[public abstract_class JavadocMd](#-public-abstract_class-javadocmd)|Punto de entrada principal del programa javadoc-md .

--- a/src/main/java/io/github/philbone/javadocmd/exporter/MarkdownBuilder.java
+++ b/src/main/java/io/github/philbone/javadocmd/exporter/MarkdownBuilder.java
@@ -80,7 +80,7 @@ public class MarkdownBuilder
     }
 
     public MarkdownBuilder toc(DocPackage docPackage) {
-        sb.append("## Resumen de Clases\n");
+        h3("Resumen de Clases\n");
         sb.append("|CLASE|DESCRIPCIÓN|\n");
         sb.append("|---|---|\n");
         for (DocClass docClass : docPackage.getClasses()) {            

--- a/src/main/java/io/github/philbone/javadocmd/exporter/MarkdownExporter.java
+++ b/src/main/java/io/github/philbone/javadocmd/exporter/MarkdownExporter.java
@@ -14,6 +14,8 @@ import io.github.philbone.javadocmd.model.*;
  *     <li>Descripción general de la clase.</li>
  *     <li>Campos, constructores y métodos con sus firmas y documentación Javadoc.</li>
  * </ul>
+ * 
+ * @project JavadocMd
  */
 public class MarkdownExporter implements DocExporter {
 
@@ -22,8 +24,12 @@ public class MarkdownExporter implements DocExporter {
         MarkdownBuilder builder = new MarkdownBuilder();
         //boolean firstClass = true;
 
-        // Encabezado principal        
-        builder.title("`" + docPackage.getName() + "`");
+        // Encabezado principal
+        if (docPackage.getProjectName() != null && !docPackage.getProjectName().isEmpty()) {
+            builder.title(docPackage.getProjectName());
+        }
+        
+        builder.subtitle(docPackage.getName());
         
         // TOC
         builder.toc(docPackage);

--- a/src/main/java/io/github/philbone/javadocmd/exporter/README.md
+++ b/src/main/java/io/github/philbone/javadocmd/exporter/README.md
@@ -1,6 +1,10 @@
-# `io.github.philbone.javadocmd.exporter`
+# JavadocMd
 
-## Resumen de Clases
+## io.github.philbone.javadocmd.exporter
+
+### Resumen de Clases
+
+
 |CLASE|DESCRIPCIÓN|
 |---|---|
 |[public interface DocExporter](#-public-interface-docexporter)|

--- a/src/main/java/io/github/philbone/javadocmd/extractor/JavadocUtils.java
+++ b/src/main/java/io/github/philbone/javadocmd/extractor/JavadocUtils.java
@@ -1,0 +1,120 @@
+package io.github.philbone.javadocmd.extractor;
+
+import com.github.javaparser.ast.comments.JavadocComment;
+import com.github.javaparser.javadoc.Javadoc;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Utilidades para trabajar con JavadocComment de JavaParser.
+ * <p>
+ * Provee métodos para:
+ * <ul>
+ *   <li>extraer una descripción "limpia" (heurística configurable),</li>
+ *   <li>extraer la etiqueta @project (si existe),</li>
+ *   <li>obtener una "descripción completa" que incluye los block tags (útil para debugging / fallback).</li>
+ * </ul>
+ */
+public class JavadocUtils
+{
+    private static final List<String> TECHNICAL_TAGS = List.of(
+            "author", "param", "return", "throws", "exception", "project"
+    );
+
+    // --- Helper: parse limpio (defensivo) ---
+    private static Javadoc parseCleaning(JavadocComment comment) {
+        String raw = comment.getContent();
+        if (raw == null) raw = "";
+        raw = raw.trim();
+        // Si accidentalmente se pasó el bloque /** ... */ en bruto, limpiarlo
+        if (raw.startsWith("/**")) {
+            raw = raw.replaceAll("^/\\*\\*", "");
+        }
+        if (raw.endsWith("*/")) {
+            raw = raw.replaceAll("\\*/$", "");
+        }
+        raw = raw.trim();
+        return new JavadocComment(raw).parse();
+    }
+
+    /**
+     * Extrae la descripción "preferida" desde un JavadocComment.
+     * <p>
+     *  - Si existe texto libre en la parte de descripción (antes de las etiquetas), lo devuelve.
+     *  - Si no, intenta devolver el primer blockTag que no sea técnico
+     *    (por ejemplo: @since, @note, etc., siempre que no esté en TECHNICAL_TAGS).
+     *  - Si no encuentra nada, devuelve cadena vacía.
+     */
+    public static String extractDescription(Optional<JavadocComment> maybeComment) {
+        if (maybeComment == null || maybeComment.isEmpty()) return "";
+
+        Javadoc javadoc = parseCleaning(maybeComment.get());
+
+        String mainDesc = javadoc.getDescription().toText().trim();
+        if (!mainDesc.isEmpty()) return mainDesc;
+
+        return javadoc.getBlockTags().stream()
+                .filter(tag -> {
+                    String tagName = tag.getTagName();
+                    return tagName == null || !TECHNICAL_TAGS.contains(tagName.toLowerCase());
+                })
+                .map(tag -> tag.getContent().toText().trim())
+                .filter(s -> !s.isEmpty())
+                .findFirst()
+                .orElse("");
+    }
+
+    /**
+     * Extrae el contenido del primer tag {@code @project} (si existe).
+     * Devuelve Optional.empty() si no está presente.
+     */
+    public static Optional<String> extractProjectTag(Optional<JavadocComment> maybeComment) {
+        if (maybeComment == null || maybeComment.isEmpty()) return Optional.empty();
+
+        Javadoc javadoc = parseCleaning(maybeComment.get());
+
+        return javadoc.getBlockTags().stream()
+                .filter(tag -> {
+                    String tn = tag.getTagName();
+                    return tn != null && tn.equalsIgnoreCase("project");
+                })
+                .map(tag -> tag.getContent().toText().trim())
+                .filter(s -> !s.isEmpty())
+                .findFirst();
+    }
+
+    /**
+     * Devuelve la "descripción completa" del Javadoc, incluyendo los block tags
+     * en forma textual, pero ignorando {@code @project}.
+     */
+    public static String extractFullDescription(Optional<JavadocComment> maybeComment) {
+        if (maybeComment == null || maybeComment.isEmpty()) return "";
+
+        Javadoc javadoc = parseCleaning(maybeComment.get());
+        StringBuilder sb = new StringBuilder();
+
+        String main = javadoc.getDescription().toText().trim();
+        if (!main.isEmpty()) {
+            sb.append(main);
+        }
+
+        javadoc.getBlockTags().stream()
+                .filter(tag -> {
+                    String name = tag.getTagName();
+                    return name == null || !name.equalsIgnoreCase("project");
+                })
+                .forEach(tag -> {
+                    if (sb.length() > 0) sb.append("\n");
+                    String name = tag.getTagName();
+                    if (name == null) name = "";
+                    String content = tag.getContent().toText().trim();
+                    sb.append("@").append(name);
+                    if (!content.isEmpty()) {
+                        sb.append(" ").append(content);
+                    }
+                });
+
+        return sb.toString().trim();
+    }
+}

--- a/src/main/java/io/github/philbone/javadocmd/extractor/README.md
+++ b/src/main/java/io/github/philbone/javadocmd/extractor/README.md
@@ -1,9 +1,14 @@
-# `io.github.philbone.javadocmd.extractor`
+# JavadocMd
 
-## Resumen de Clases
+## io.github.philbone.javadocmd.extractor
+
+### Resumen de Clases
+
+
 |CLASE|DESCRIPCIÓN|
 |---|---|
 |[public class JavadocExtractorVisitor](#-public-class-javadocextractorvisitor)|Visitor encargado de recorrer los nodos del AST de JavaParser y construir el modelo intermedio para la documentación en Markdown.
+|[public class JavadocUtils](#-public-class-javadocutils)|Utilidades para trabajar con JavadocComment de JavaParser.
 ---
 
 ## 📘 Public Class JavadocExtractorVisitor
@@ -32,7 +37,6 @@ extends VoidVisitorAdapter
 - `private void visitMethod(MethodDeclaration n, DocClass docClass)`
 - `private void visitConstructor(ConstructorDeclaration n, DocClass docClass)`
 - `private void visitField(FieldDeclaration n, DocClass docClass)`
-- `private String extractDescription(BodyDeclaration<?> n)`
 - `private Javadoc extractJavadoc(BodyDeclaration<?> n)`
 - `private String extractVisibility(BodyDeclaration<?> n)`
 > Extrae la visibilidad de un nodo que posea modificadores.
@@ -44,3 +48,43 @@ extends VoidVisitorAdapter
 
 > - *@param* **n** nodo del AST.
 > - *@return* {@code true} si el nodo es estático, {@code false} en caso contrario.
+- `private void extractProjectNameAndDescription(ClassOrInterfaceDeclaration n, DocPackage docPackage, DocClass docClass)`
+---
+
+## 📘 Public Class JavadocUtils
+
+```java
+public class JavadocUtils
+```
+> **Descripción:**
+> Utilidades para trabajar con JavadocComment de JavaParser.
+> <p>
+> Provee métodos para:
+> <ul>
+>   <li>extraer una descripción "limpia" (heurística configurable),</li>
+>   <li>extraer la etiqueta @project (si existe),</li>
+>   <li>obtener una "descripción completa" que incluye los block tags (útil para debugging / fallback).</li>
+> </ul>
+
+## 📦 Campos
+
+- `private static List<String> TECHNICAL_TAGS`
+## 🧮 Métodos
+
+- `private static Javadoc parseCleaning(JavadocComment comment)`
+- `public static String extractDescription(Optional<JavadocComment> maybeComment)`
+> Extrae la descripción "preferida" desde un JavadocComment.
+> <p>
+>  - Si existe texto libre en la parte de descripción (antes de las etiquetas), lo devuelve.
+>  - Si no, intenta devolver el primer blockTag que no sea técnico
+>    (por ejemplo: @since, @note, etc., siempre que no esté en TECHNICAL_TAGS).
+>  - Si no encuentra nada, devuelve cadena vacía.
+
+- `public static Optional<String> extractProjectTag(Optional<JavadocComment> maybeComment)`
+> Extrae el contenido del primer tag {@code @project} (si existe).
+> Devuelve Optional.empty() si no está presente.
+
+- `public static String extractFullDescription(Optional<JavadocComment> maybeComment)`
+> Devuelve la "descripción completa" del Javadoc, incluyendo los block tags
+> en forma textual, pero ignorando {@code @project}.
+

--- a/src/main/java/io/github/philbone/javadocmd/model/DocClass.java
+++ b/src/main/java/io/github/philbone/javadocmd/model/DocClass.java
@@ -28,10 +28,7 @@ import java.util.List;
 public class DocClass {
 
     /** Nombre simple de la clase, interfaz, enum o record. */
-    private final String name;
-
-    /** Descripción principal tomada del comentario Javadoc asociado. */
-    private final String description;
+    private final String name;   
 
     /** Tipo de elemento representado (clase, interfaz, enum, record, abstracta). */
     private final Kind kind;
@@ -56,6 +53,9 @@ public class DocClass {
 
     /** Interfaces implementadas (clases) o extendidas (interfaces). */
     private final List<String> interfaces = new ArrayList<>();
+    
+    /** Descripción principal tomada del comentario Javadoc asociado. */
+    private String description;
 
     /**
      * Crea una nueva representación de clase en el modelo intermedio.
@@ -148,4 +148,6 @@ public class DocClass {
      * @param iface nombre de la interfaz
      */
     public void addInterface(String iface) { this.interfaces.add(iface); }
+
+    public void setDescription(String description) { this.description = description; }
 }

--- a/src/main/java/io/github/philbone/javadocmd/model/DocPackage.java
+++ b/src/main/java/io/github/philbone/javadocmd/model/DocPackage.java
@@ -3,19 +3,89 @@ package io.github.philbone.javadocmd.model;
 import java.util.ArrayList;
 import java.util.List;
 
-public class DocPackage
-{
-    private String name;
-    private List<DocClass> classes = new ArrayList<>();
+/**
+ * Representa un paquete de Java dentro del modelo intermedio de documentación.
+ * <p>
+ * Esta clase agrupa todas las {@link DocClass} (clases, interfaces, enums y records)
+ * pertenecientes a un mismo paquete, junto con su nombre.
+ * Es utilizada como unidad base por los exportadores para generar la documentación.
+ * </p>
+ *
+ * <h2>Responsabilidades:</h2>
+ * <ul>
+ *   <li>Almacenar el nombre del paquete analizado.</li>
+ *   <li>Contener la colección de clases, interfaces, enums y records del paquete.</li>
+ *   <li>Proveer métodos para acceder y agregar clases al paquete.</li>
+ * </ul>
+ *
+ * <h2>Uso típico:</h2>
+ * Un {@code DocPackage} se crea durante la fase de extracción de Javadoc
+ * y posteriormente es consumido por un {@code DocExporter} para generar la salida
+ * (por ejemplo, en formato Markdown).
+ *
+ * <pre>{@code
+ * DocPackage pkg = new DocPackage("io.github.philbone.javadocmd.exporter");
+ * pkg.addClass(new DocClass("MarkdownExporter", "...", Kind.CLASS, "public", false));
+ * }</pre>
+ *
+ * @project JavadocMd
+ * @author Felipe M. philbone@focused.cl
+ * 
+ */
+public class DocPackage {
 
+    /** Nombre completo del paquete (ejemplo: {@code io.github.philbone.javadocmd.exporter}). */
+    private final String name;
+
+    /** Conjunto de clases, interfaces, enums y records pertenecientes al paquete. */
+    private final List<DocClass> classes = new ArrayList<>();
+    private String projectName;
+
+    /**
+     * Crea un nuevo descriptor de paquete.
+     *
+     * @param name nombre del paquete en notación estándar de Java.
+     */
     public DocPackage(String name) {
         this.name = name;
     }
 
-    public String getName() { return name; }
-    public List<DocClass> getClasses() { return classes; }
+    /**
+     * Obtiene el nombre del paquete.
+     *
+     * @return nombre completo del paquete.
+     */
+    public String getName() {
+        return name;
+    }
 
+    /**
+     * Devuelve la lista de clases, interfaces, enums y records que pertenecen al paquete.
+     * <p>
+     * La lista devuelta es la instancia interna; se recomienda usar
+     * {@link #addClass(DocClass)} para agregar elementos en lugar de modificarla directamente.
+     * </p>
+     *
+     * @return lista de clases del paquete.
+     */
+    public List<DocClass> getClasses() {
+        return classes;
+    }
+
+    /**
+     * Agrega una nueva clase, interfaz, enum o record al paquete.
+     *
+     * @param docClass instancia de {@link DocClass} a agregar.
+     */
     public void addClass(DocClass docClass) {
         classes.add(docClass);
+    }
+
+    public void setProjectName(String projectName) {
+        this.projectName = projectName;
+    }
+
+    public String getProjectName() {
+        return projectName;
     }
 }

--- a/src/main/java/io/github/philbone/javadocmd/model/README.md
+++ b/src/main/java/io/github/philbone/javadocmd/model/README.md
@@ -1,13 +1,17 @@
-# `io.github.philbone.javadocmd.model`
+# JavadocMd
 
-## Resumen de Clases
+## io.github.philbone.javadocmd.model
+
+### Resumen de Clases
+
+
 |CLASE|DESCRIPCIÓN|
 |---|---|
 |[public class DocConstructor](#-public-class-docconstructor)|Representa un constructor documentado dentro de una clase.
 |[public class DocClass](#-public-class-docclass)|Representa la definición de una clase, interfaz, enum o record dentro del modelo intermedio de documentación.
 |[public class DocMethod](#-public-class-docmethod)|
 |[public class DocParameter](#-public-class-docparameter)|
-|[public class DocPackage](#-public-class-docpackage)|
+|[public class DocPackage](#-public-class-docpackage)|Representa un paquete de Java dentro del modelo intermedio de documentación.
 |[public enum Kind](#-public-enum-kind)|
 |[public class DocException](#-public-class-docexception)|
 |[public class DocField](#-public-class-docfield)|Representa un campo (atributo) documentado dentro de una clase.
@@ -72,9 +76,6 @@ public class DocClass
 - `private String name`
 > Nombre simple de la clase, interfaz, enum o record.
 
-- `private String description`
-> Descripción principal tomada del comentario Javadoc asociado.
-
 - `private Kind kind`
 > Tipo de elemento representado (clase, interfaz, enum, record, abstracta).
 
@@ -98,6 +99,9 @@ public class DocClass
 
 - `private List<String> interfaces`
 > Interfaces implementadas (clases) o extendidas (interfaces).
+
+- `private String description`
+> Descripción principal tomada del comentario Javadoc asociado.
 
 ## 🛠️ Constructores
 
@@ -152,6 +156,7 @@ public class DocClass
 > Agrega una interfaz implementada o extendida.
 
 > - *@param* **iface** nombre de la interfaz
+- `public void setDescription(String description)`
 ---
 
 ## 📘 Public Class DocMethod
@@ -212,18 +217,67 @@ public class DocParameter
 ```java
 public class DocPackage
 ```
+> **Descripción:**
+> Representa un paquete de Java dentro del modelo intermedio de documentación.
+> <p>
+> Esta clase agrupa todas las {@link DocClass} (clases, interfaces, enums y records)
+> pertenecientes a un mismo paquete, junto con su nombre.
+> Es utilizada como unidad base por los exportadores para generar la documentación.
+> </p>
+> 
+> <h2>Responsabilidades:</h2>
+> <ul>
+>   <li>Almacenar el nombre del paquete analizado.</li>
+>   <li>Contener la colección de clases, interfaces, enums y records del paquete.</li>
+>   <li>Proveer métodos para acceder y agregar clases al paquete.</li>
+> </ul>
+> 
+> <h2>Uso típico:</h2>
+> Un {@code DocPackage} se crea durante la fase de extracción de Javadoc
+> y posteriormente es consumido por un {@code DocExporter} para generar la salida
+> (por ejemplo, en formato Markdown).
+> 
+> <pre>{@code
+> DocPackage pkg = new DocPackage("io.github.philbone.javadocmd.exporter");
+> pkg.addClass(new DocClass("MarkdownExporter", "...", Kind.CLASS, "public", false));
+> }</pre>
+
 ## 📦 Campos
 
 - `private String name`
+> Nombre completo del paquete (ejemplo: {@code io.github.philbone.javadocmd.exporter}).
+
 - `private List<DocClass> classes`
+> Conjunto de clases, interfaces, enums y records pertenecientes al paquete.
+
+- `private String projectName`
 ## 🛠️ Constructores
 
 - `public DocPackage(String name)`
+> **Descripción:**
+> Crea un nuevo descriptor de paquete.
+
+> - *@param* `name`nombre del paquete en notación estándar de Java.
 ## 🧮 Métodos
 
 - `public String getName()`
+> Obtiene el nombre del paquete.
+
+> - *@return* nombre completo del paquete.
 - `public List<DocClass> getClasses()`
+> Devuelve la lista de clases, interfaces, enums y records que pertenecen al paquete.
+> <p>
+> La lista devuelta es la instancia interna; se recomienda usar
+> {@link #addClass(DocClass)} para agregar elementos en lugar de modificarla directamente.
+> </p>
+
+> - *@return* lista de clases del paquete.
 - `public void addClass(DocClass docClass)`
+> Agrega una nueva clase, interfaz, enum o record al paquete.
+
+> - *@param* **docClass** instancia de {@link DocClass} a agregar.
+- `public void setProjectName(String projectName)`
+- `public String getProjectName()`
 ---
 
 ## 📙 Public Enum Kind

--- a/src/test/java/JavadocUtilsTest.java
+++ b/src/test/java/JavadocUtilsTest.java
@@ -1,0 +1,89 @@
+import io.github.philbone.javadocmd.extractor.JavadocUtils;
+import com.github.javaparser.ast.comments.JavadocComment;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Optional;
+
+class JavadocUtilsTest {
+
+    // ======== extractProjectTag ======== //
+
+    @Test
+    void extractProjectTag_debeExtraerNombreDelProyecto() {
+        String source = """
+                /**
+                 * @project JavadocMd
+                 * Esta clase genera documentación Markdown.
+                 */
+                """;
+        JavadocComment comment = new JavadocComment(source);
+        Optional<String> project = JavadocUtils.extractProjectTag(Optional.of(comment));
+
+        assertTrue(project.isPresent());
+        assertEquals("JavadocMd", project.get());
+    }
+
+    @Test
+    void extractProjectTag_debeRetornarVacioSiNoHayProject() {
+        String source = """
+                /**
+                 * Clase sin tag de proyecto.
+                 */
+                """;
+        JavadocComment comment = new JavadocComment(source);
+        Optional<String> project = JavadocUtils.extractProjectTag(Optional.of(comment));
+
+        assertTrue(project.isEmpty());
+    }
+
+    // ======== extractFullDescription ======== //
+
+    @Test
+    void extractFullDescription_debeIncluirTextoYTags() {
+        String source = """
+                /**
+                 * Clase encargada de procesar datos.
+                 *
+                 * @author Felipe
+                 * @version 1.0
+                 */
+                """;
+        JavadocComment comment = new JavadocComment(source);
+        String result = JavadocUtils.extractFullDescription(Optional.of(comment));
+
+        assertTrue(result.contains("Clase encargada de procesar datos."));
+        assertTrue(result.contains("@author"));
+        assertTrue(result.contains("@version"));
+    }
+
+    @Test
+    void extractFullDescription_debeExcluirTagProject() {
+        String source = """
+                /**
+                 * @project JavadocMd
+                 * Este es el extractor de javadoc.
+                 */
+                """;
+        JavadocComment comment = new JavadocComment(source);
+        String result = JavadocUtils.extractFullDescription(Optional.of(comment));
+
+        // Debe eliminar el tag @project
+        assertFalse(result.contains("@project"));
+        // Debe mantener el texto descriptivo
+        assertEquals("Este es el extractor de javadoc.", result.trim());
+    }
+
+    @Test
+    void extractFullDescription_debeManejarDescripcionSinTags() {
+        String source = """
+                /**
+                 * Clase simple sin tags adicionales.
+                 */
+                """;
+        JavadocComment comment = new JavadocComment(source);
+        String result = JavadocUtils.extractFullDescription(Optional.of(comment));
+
+        assertEquals("Clase simple sin tags adicionales.", result.trim());
+    }
+}


### PR DESCRIPTION
… tag

- Se implementó la extracción del nombre del proyecto desde el tag @project.
- Si el tag no está presente, se intenta inferir el nombre desde la clase con método main.
- Se agregó soporte para fallback (sin título si no se encuentra nombre).
- Se creó utilitario `JavadocUtils` con métodos:
  - extractDescription
  - extractProjectTag
  - extractFullDescription
- Se añadieron pruebas unitarias para los nuevos métodos.
- Issue pendiente: parsing incorrecto cuando el Javadoc inicia con un tag (ver #43).

close: #31