### PR TITLE
feat(exporter): agregar bloques colapsables <details> para clases en …

### DIFF
--- a/src/main/java/io/github/philbone/javadocmd/README.md
+++ b/src/main/java/io/github/philbone/javadocmd/README.md
@@ -2,14 +2,12 @@
 
 ## io.github.philbone.javadocmd
 
-### Resumen de Clases
+## Resumen de Clases
 
 
 |CLASE|DESCRIPCIÓN|
 |---|---|
 |[public abstract_class JavadocMd](#-public-abstract_class-javadocmd)|Punto de entrada principal del programa javadoc-md .
----
-
 ## 📕 Public Abstract Class JavadocMd
 
 ```java
@@ -32,7 +30,7 @@ public abstract class JavadocMd
 > Actualmente soporta la exportación de documentación hacia un archivo
 > <code>README.md</code> por cada paquete encontrado en el proyecto.</p>
 
-## 📦 Campos
+### 📦 Campos
 
 - `private static String outFileName`
 > Nombre por defecto del archivo de salida que contendrá la documentación
@@ -50,7 +48,7 @@ public abstract class JavadocMd
 - `private static boolean debug`
 > Bandera de depuración para imprimir trazas adicionales.
 
-## 🛠️ Constructores
+### 🛠️ Constructores
 
 - `protected JavadocMd()`
 > **Descripción:**
@@ -59,7 +57,7 @@ public abstract class JavadocMd
 > Inicializa valores de configuración básicos.
 
 > - *@throws* **IllegalStateException** si la configuración inicial es inválida.
-## 🧮 Métodos
+### 🧮 Métodos
 
 - `public static void main(String[] args)`
 > Método principal que inicia el proceso de generación de documentación.

--- a/src/main/java/io/github/philbone/javadocmd/exporter/MarkdownBuilder.java
+++ b/src/main/java/io/github/philbone/javadocmd/exporter/MarkdownBuilder.java
@@ -22,6 +22,11 @@ public class MarkdownBuilder
         sb.append("### ").append(text).append("\n\n");
         return this;
     }
+    
+    public MarkdownBuilder h4(String text) {        
+        sb.append("#### ").append(text).append("\n\n");
+        return this;
+    }
 
     public MarkdownBuilder paragraph(String text) {
         sb.append(text).append("\n\n");
@@ -80,7 +85,7 @@ public class MarkdownBuilder
     }
 
     public MarkdownBuilder toc(DocPackage docPackage) {
-        h3("Resumen de Clases\n");
+        subtitle("Resumen de Clases\n");
         sb.append("|CLASE|DESCRIPCIÓN|\n");
         sb.append("|---|---|\n");
         for (DocClass docClass : docPackage.getClasses()) {            

--- a/src/main/java/io/github/philbone/javadocmd/exporter/MarkdownExporter.java
+++ b/src/main/java/io/github/philbone/javadocmd/exporter/MarkdownExporter.java
@@ -17,7 +17,14 @@ import io.github.philbone.javadocmd.model.*;
  * 
  * @project JavadocMd
  */
-public class MarkdownExporter implements DocExporter {
+public class MarkdownExporter implements DocExporter
+{
+   /**
+    * 
+    * Número mínimo de clases dentro de un paquete para activar el modo colapsable.
+    * Si el paquete tiene más de este número, cada clase se renderiza dentro de un bloque <details>.
+    */
+    private static final int COLLAPSE_THRESHOLD = 4;
 
     @Override
     public String export(DocPackage docPackage) {
@@ -34,19 +41,22 @@ public class MarkdownExporter implements DocExporter {
         // TOC
         builder.toc(docPackage);
 
+        // Determinar si se deben colapsar las clases
+        boolean collapseClasses = docPackage.getClasses().size() > COLLAPSE_THRESHOLD;
+
         // Recorrer clases / interfaces / enums / records
         for (DocClass docClass : docPackage.getClasses()) {
-            //if (!firstClass) {
-                builder.paragraph("---"); // separador entre clases
-            //}
-            //firstClass = false;
-
             String emoji = formatEmoji(docClass.getKind());
-            String header = emoji + " " 
+            String header = emoji + " "
                     + capitalize(docClass.getVisibility())
                     + (docClass.isStatic() ? " static " : " ")
                     + formatKind(docClass.getKind())
                     + " " + docClass.getName();
+
+            if (collapseClasses) {
+                builder.tag("<details>\n");
+                builder.tag("<summary> <strong>"+ header.trim() +"</strong> </summary>\n\n");
+            }
 
             builder.subtitle(header.trim());
 
@@ -83,7 +93,7 @@ public class MarkdownExporter implements DocExporter {
 
             // 📦 Campos
             if (!docClass.getFields().isEmpty()) {
-                builder.subtitle("📦 Campos");
+                builder.h3("📦 Campos");
                 for (DocField field : docClass.getFields()) {
                     String signatureField = field.getVisibility()
                             + (field.isStatic() ? " static" : "")
@@ -99,7 +109,7 @@ public class MarkdownExporter implements DocExporter {
 
             // 🛠️ Constructores
             if (!docClass.getConstructors().isEmpty()) {
-                builder.subtitle("🛠️ Constructores");
+                builder.h3("🛠️ Constructores");
                 for (DocConstructor constructor : docClass.getConstructors()) {
                     String signatureCons = constructor.getVisibility()
                             + (constructor.isStatic() ? " static " : " ")
@@ -125,7 +135,7 @@ public class MarkdownExporter implements DocExporter {
 
             // 🧮 Métodos
             if (!docClass.getMethods().isEmpty()) {
-                builder.subtitle("🧮 Métodos");
+                builder.h3("🧮 Métodos");
                 for (DocMethod method : docClass.getMethods()) {
                     String signatureMeth = method.getVisibility()
                             + (method.isStatic() ? " static" : "")
@@ -153,6 +163,10 @@ public class MarkdownExporter implements DocExporter {
                         builder.listItem("*@throws* **" + ex.getName() + "** " + ex.getDescription());                        
                     }
                 }
+            }
+            
+            if (collapseClasses) {
+                builder.tag("\n</details>\n");
             }
         }
 

--- a/src/main/java/io/github/philbone/javadocmd/exporter/README.md
+++ b/src/main/java/io/github/philbone/javadocmd/exporter/README.md
@@ -2,7 +2,7 @@
 
 ## io.github.philbone.javadocmd.exporter
 
-### Resumen de Clases
+## Resumen de Clases
 
 
 |CLASE|DESCRIPCIÓN|
@@ -10,18 +10,14 @@
 |[public interface DocExporter](#-public-interface-docexporter)|
 |[public class MarkdownExporter](#-public-class-markdownexporter)|Exportador que genera documentación en formato Markdown a partir del modelo intermedio construido con {@link io.
 |[public class MarkdownBuilder](#-public-class-markdownbuilder)|
----
-
 ## 📗 Public Interface DocExporter
 
 ```java
 public interface DocExporter
 ```
-## 🧮 Métodos
+### 🧮 Métodos
 
 - `package-private String export(DocPackage docPackage)`
----
-
 ## 📘 Public Class MarkdownExporter
 
 ```java
@@ -41,27 +37,32 @@ implements DocExporter
 >     <li>Campos, constructores y métodos con sus firmas y documentación Javadoc.</li>
 > </ul>
 
-## 🧮 Métodos
+### 📦 Campos
+
+- `private static int COLLAPSE_THRESHOLD`
+> Número mínimo de clases dentro de un paquete para activar el modo colapsable.
+> Si el paquete tiene más de este número, cada clase se renderiza dentro de un bloque <details>.
+
+### 🧮 Métodos
 
 - `public String export(DocPackage docPackage)`
 - `private String formatKind(Kind kind)`
 - `private String capitalize(String s)`
 - `private String formatEmoji(Kind kind)`
----
-
 ## 📘 Public Class MarkdownBuilder
 
 ```java
 public class MarkdownBuilder
 ```
-## 📦 Campos
+### 📦 Campos
 
 - `private StringBuilder sb`
-## 🧮 Métodos
+### 🧮 Métodos
 
 - `public MarkdownBuilder title(String text)`
 - `public MarkdownBuilder subtitle(String text)`
 - `public MarkdownBuilder h3(String text)`
+- `public MarkdownBuilder h4(String text)`
 - `public MarkdownBuilder paragraph(String text)`
 - `public MarkdownBuilder listItem(String text)`
 - `public String build()`

--- a/src/main/java/io/github/philbone/javadocmd/extractor/README.md
+++ b/src/main/java/io/github/philbone/javadocmd/extractor/README.md
@@ -2,15 +2,13 @@
 
 ## io.github.philbone.javadocmd.extractor
 
-### Resumen de Clases
+## Resumen de Clases
 
 
 |CLASE|DESCRIPCIÓN|
 |---|---|
 |[public class JavadocExtractorVisitor](#-public-class-javadocextractorvisitor)|Visitor encargado de recorrer los nodos del AST de JavaParser y construir el modelo intermedio para la documentación en Markdown.
 |[public class JavadocUtils](#-public-class-javadocutils)|Utilidades para trabajar con JavadocComment de JavaParser.
----
-
 ## 📘 Public Class JavadocExtractorVisitor
 
 ```java
@@ -29,7 +27,7 @@ extends VoidVisitorAdapter
 >   <li>Registra métodos, constructores y campos de cada clase.</li>
 > </ul>
 
-## 🧮 Métodos
+### 🧮 Métodos
 
 - `public void visit(ClassOrInterfaceDeclaration n, DocPackage docPackage)`
 - `public void visit(EnumDeclaration n, DocPackage docPackage)`
@@ -49,8 +47,6 @@ extends VoidVisitorAdapter
 > - *@param* **n** nodo del AST.
 > - *@return* {@code true} si el nodo es estático, {@code false} en caso contrario.
 - `private void extractProjectNameAndDescription(ClassOrInterfaceDeclaration n, DocPackage docPackage, DocClass docClass)`
----
-
 ## 📘 Public Class JavadocUtils
 
 ```java
@@ -66,10 +62,10 @@ public class JavadocUtils
 >   <li>obtener una "descripción completa" que incluye los block tags (útil para debugging / fallback).</li>
 > </ul>
 
-## 📦 Campos
+### 📦 Campos
 
 - `private static List<String> TECHNICAL_TAGS`
-## 🧮 Métodos
+### 🧮 Métodos
 
 - `private static Javadoc parseCleaning(JavadocComment comment)`
 - `public static String extractDescription(Optional<JavadocComment> maybeComment)`

--- a/src/main/java/io/github/philbone/javadocmd/model/README.md
+++ b/src/main/java/io/github/philbone/javadocmd/model/README.md
@@ -2,7 +2,7 @@
 
 ## io.github.philbone.javadocmd.model
 
-### Resumen de Clases
+## Resumen de Clases
 
 
 |CLASE|DESCRIPCIÓN|
@@ -15,7 +15,8 @@
 |[public enum Kind](#-public-enum-kind)|
 |[public class DocException](#-public-class-docexception)|
 |[public class DocField](#-public-class-docfield)|Representa un campo (atributo) documentado dentro de una clase.
----
+<details>
+<summary> <strong>📘 Public Class DocConstructor</strong> </summary>
 
 ## 📘 Public Class DocConstructor
 
@@ -25,7 +26,7 @@ public class DocConstructor
 > **Descripción:**
 > Representa un constructor documentado dentro de una clase.
 
-## 📦 Campos
+### 📦 Campos
 
 - `private String name`
 - `private List<String> parameters`
@@ -34,10 +35,10 @@ public class DocConstructor
 - `private boolean isStatic`
 - `private List<DocParameter> docParameters`
 - `private List<DocException> exceptions`
-## 🛠️ Constructores
+### 🛠️ Constructores
 
 - `public DocConstructor(String name, List<String> parameters, String description, String visibility, boolean isStatic)`
-## 🧮 Métodos
+### 🧮 Métodos
 
 - `public String getName()`
 - `public List<String> getParameters()`
@@ -48,7 +49,10 @@ public class DocConstructor
 - `public List<DocParameter> getDocParameters()`
 - `public void addException(DocException exception)`
 - `public List<DocException> getExceptions()`
----
+
+</details>
+<details>
+<summary> <strong>📘 Public Class DocClass</strong> </summary>
 
 ## 📘 Public Class DocClass
 
@@ -71,7 +75,7 @@ public class DocClass
 > La información contenida en esta clase es utilizada por los exportadores (por ejemplo, {@code MarkdownExporter}) para generar documentación en distintos formatos.
 > </p>
 
-## 📦 Campos
+### 📦 Campos
 
 - `private String name`
 > Nombre simple de la clase, interfaz, enum o record.
@@ -103,7 +107,7 @@ public class DocClass
 - `private String description`
 > Descripción principal tomada del comentario Javadoc asociado.
 
-## 🛠️ Constructores
+### 🛠️ Constructores
 
 - `public DocClass(String name, String description, Kind kind, String visibility, boolean isStatic)`
 > **Descripción:**
@@ -114,7 +118,7 @@ public class DocClass
 > - *@param* `kind`tipo del elemento (clase, interfaz, enum, record)
 > - *@param* `visibility`nivel de visibilidad (public, protected, package-private, private)
 > - *@param* `isStatic`indica si la clase fue declarada como {@code static}
-## 🧮 Métodos
+### 🧮 Métodos
 
 - `public String getName()`
 > - *@return* el nombre simple de la clase.
@@ -157,14 +161,17 @@ public class DocClass
 
 > - *@param* **iface** nombre de la interfaz
 - `public void setDescription(String description)`
----
+
+</details>
+<details>
+<summary> <strong>📘 Public Class DocMethod</strong> </summary>
 
 ## 📘 Public Class DocMethod
 
 ```java
 public class DocMethod
 ```
-## 📦 Campos
+### 📦 Campos
 
 - `private String name`
 - `private String returnType`
@@ -175,10 +182,10 @@ public class DocMethod
 - `private String returnDescription`
 - `private List<DocParameter> docParameters`
 - `private List<DocException> exceptions`
-## 🛠️ Constructores
+### 🛠️ Constructores
 
 - `public DocMethod(String name, String returnType, List<String> parameters, String description, String visibility, boolean isStatic)`
-## 🧮 Métodos
+### 🧮 Métodos
 
 - `public String getName()`
 - `public String getReturnType()`
@@ -192,25 +199,31 @@ public class DocMethod
 - `public List<DocParameter> getDocParameters()`
 - `public void addException(DocException exception)`
 - `public List<DocException> getExceptions()`
----
+
+</details>
+<details>
+<summary> <strong>📘 Public Class DocParameter</strong> </summary>
 
 ## 📘 Public Class DocParameter
 
 ```java
 public class DocParameter
 ```
-## 📦 Campos
+### 📦 Campos
 
 - `private String name`
 - `private String description`
-## 🛠️ Constructores
+### 🛠️ Constructores
 
 - `public DocParameter(String name, String description)`
-## 🧮 Métodos
+### 🧮 Métodos
 
 - `public String getName()`
 - `public String getDescription()`
----
+
+</details>
+<details>
+<summary> <strong>📘 Public Class DocPackage</strong> </summary>
 
 ## 📘 Public Class DocPackage
 
@@ -242,7 +255,7 @@ public class DocPackage
 > pkg.addClass(new DocClass("MarkdownExporter", "...", Kind.CLASS, "public", false));
 > }</pre>
 
-## 📦 Campos
+### 📦 Campos
 
 - `private String name`
 > Nombre completo del paquete (ejemplo: {@code io.github.philbone.javadocmd.exporter}).
@@ -251,14 +264,14 @@ public class DocPackage
 > Conjunto de clases, interfaces, enums y records pertenecientes al paquete.
 
 - `private String projectName`
-## 🛠️ Constructores
+### 🛠️ Constructores
 
 - `public DocPackage(String name)`
 > **Descripción:**
 > Crea un nuevo descriptor de paquete.
 
 > - *@param* `name`nombre del paquete en notación estándar de Java.
-## 🧮 Métodos
+### 🧮 Métodos
 
 - `public String getName()`
 > Obtiene el nombre del paquete.
@@ -278,32 +291,41 @@ public class DocPackage
 > - *@param* **docClass** instancia de {@link DocClass} a agregar.
 - `public void setProjectName(String projectName)`
 - `public String getProjectName()`
----
+
+</details>
+<details>
+<summary> <strong>📙 Public Enum Kind</strong> </summary>
 
 ## 📙 Public Enum Kind
 
 ```java
 public enum Kind
 ```
----
+
+</details>
+<details>
+<summary> <strong>📘 Public Class DocException</strong> </summary>
 
 ## 📘 Public Class DocException
 
 ```java
 public class DocException
 ```
-## 📦 Campos
+### 📦 Campos
 
 - `private String name`
 - `private String description`
-## 🛠️ Constructores
+### 🛠️ Constructores
 
 - `public DocException(String name, String description)`
-## 🧮 Métodos
+### 🧮 Métodos
 
 - `public String getName()`
 - `public String getDescription()`
----
+
+</details>
+<details>
+<summary> <strong>📘 Public Class DocField</strong> </summary>
 
 ## 📘 Public Class DocField
 
@@ -313,20 +335,22 @@ public class DocField
 > **Descripción:**
 > Representa un campo (atributo) documentado dentro de una clase.
 
-## 📦 Campos
+### 📦 Campos
 
 - `private String name`
 - `private String type`
 - `private String description`
 - `private String visibility`
 - `private boolean isStatic`
-## 🛠️ Constructores
+### 🛠️ Constructores
 
 - `public DocField(String name, String type, String description, String visibility, boolean isStatic)`
-## 🧮 Métodos
+### 🧮 Métodos
 
 - `public String getName()`
 - `public String getType()`
 - `public String getDescription()`
 - `public String getVisibility()`
 - `public boolean isStatic()`
+
+</details>


### PR DESCRIPTION
…paquetes grandes (#15)

Se implementa soporte para renderizar las clases dentro de bloques <details> en Markdown cuando el paquete contiene más de 4 clases. Esto permite colapsar secciones extensas y mejorar la navegación en paquetes con muchas clases.

- Se agrega constante `COLLAPSE_THRESHOLD = 4`.
- Cada clase se encapsula en `<details><summary>...</summary>...</details>` si aplica.
- Mantiene el comportamiento anterior para paquetes pequeños.
- Agrega el método h4() al MarkdownBuilder.

close: #15