### PR TITLE
feat(exporter): soporte para incrustar imágenes en la documentación M…

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,12 @@ Utilidades matemáticas.
   **return:** la suma de ambos números  
 
 ## 🧭 Roadmap
-  * [ ] Generar .md automáticamente por paquete.
-  * [ ] Soporte para documentación de constructores.
-  * [ ] Exportar también atributos con sus Javadocs.
+  * [x] Generar .md automáticamente por paquete.
+  * [x] Soporte para documentación de constructores.
+  * [x] Exportar también atributos con sus Javadocs.
   * [ ] Opción CLI para elegir entre salida consolidada (.md único) o por clase.
   * [ ] Opción CLI para cambiar el nombre del md.
   * [ ] Opción CLI para incluir un md el directorio raíz.
   * [ ] Posible extensión para BlueJ/NetBeans/Eclipse.
+
+<img width="100%" src="https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExaHNnOHpuN3VvcjJzcHRmNGVwZzVwcW02ZTQ5MTk2a2Y5YXczNTExdCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/wwg1suUiTbCY8H8vIA/giphy.gif">

--- a/src/main/java/io/github/philbone/javadocmd/exporter/MarkdownExporter.java
+++ b/src/main/java/io/github/philbone/javadocmd/exporter/MarkdownExporter.java
@@ -1,5 +1,6 @@
 package io.github.philbone.javadocmd.exporter;
 
+import io.github.philbone.javadocmd.extractor.JavadocUtils;
 import io.github.philbone.javadocmd.model.*;
 
 /**
@@ -88,7 +89,8 @@ public class MarkdownExporter implements DocExporter
 
             // ========== Descripción ==========
             if (docClass.getDescription() != null && !docClass.getDescription().isEmpty()) {
-                builder.blockquote("**Descripción:**\n" + docClass.getDescription());
+                String desc = JavadocUtils.normalizeImages(docClass.getDescription());
+                builder.blockquote("**Descripción:**\n" + desc);
             }
 
             // 📦 Campos
@@ -96,14 +98,15 @@ public class MarkdownExporter implements DocExporter
                 builder.h3("📦 Campos");
                 for (DocField field : docClass.getFields()) {
                     String typeLinked = formatCodeOrLink(field.getType());
-                    String signatureField = " `" + field.getVisibility() 
+                    String signatureField = " `" + field.getVisibility()
                             + (field.isStatic() ? " static`" : "`")
                             + " " + typeLinked
                             + " `" + field.getName() + "` ";
                     builder.listItem(signatureField.trim());
 
                     if (field.getDescription() != null && !field.getDescription().isEmpty()) {
-                        builder.blockquote(field.getDescription());
+                        String desc = JavadocUtils.normalizeImages(field.getDescription());
+                        builder.blockquote(desc);
                     }
                 }
             }
@@ -119,7 +122,8 @@ public class MarkdownExporter implements DocExporter
                     builder.listItem("`" + signatureCons.trim() + "`");
 
                     if (constructor.getDescription() != null && !constructor.getDescription().isEmpty()) {
-                        builder.blockquote("**Descripción:**\n" + constructor.getDescription());
+                        String desc = JavadocUtils.normalizeImages(constructor.getDescription());
+                        builder.blockquote("**Descripción:**\n" + desc);
                     }
 
                     for (DocParameter param : constructor.getDocParameters()) {
@@ -141,13 +145,14 @@ public class MarkdownExporter implements DocExporter
                     String returnType = formatCodeOrLink(method.getReturnType());
                     String signatureMeth = " `" + method.getVisibility()
                             + (method.isStatic() ? " static`" : "`")
-                            + (method.isVoid()   ? " **void**" : returnType)
+                            + (method.isVoid() ? " **void**" : returnType)
                             + " `" + method.getName()
                             + "(" + String.join(", ", method.getParameters()) + ")`";
                     builder.listItem(signatureMeth.trim());
 
                     if (method.getDescription() != null && !method.getDescription().isEmpty()) {
-                        builder.blockquote(method.getDescription());
+                        String desc = JavadocUtils.normalizeImages(method.getDescription());
+                        builder.blockquote(desc);
                     }
 
                     for (DocParameter param : method.getDocParameters()) {
@@ -180,8 +185,7 @@ public class MarkdownExporter implements DocExporter
         if (type == null || type.isBlank()) return "";
         String url = apiLinker.linkIfJavaType(type);
         if (url != null) {
-            //return "[" + type + "](" + url + ")";
-            return url;
+            return url; // ya viene como [String](https://...) etc.
         }
         return "`" + type + "`";
     }

--- a/src/main/java/io/github/philbone/javadocmd/extractor/JavadocUtils.java
+++ b/src/main/java/io/github/philbone/javadocmd/extractor/JavadocUtils.java
@@ -117,4 +117,51 @@ public class JavadocUtils
 
         return sb.toString().trim();
     }
+    
+    /**
+     * Normaliza etiquetas HTML de imagen dentro de una descripción Javadoc.
+     * <p>
+     * Convierte etiquetas <img> en sintaxis Markdown:
+     * <pre>{@code
+     * <img src="docs/diagrama.png" alt="Diagrama">
+     * →
+     * ![Diagrama](docs/diagrama.png)
+     * }</pre>
+     *
+     * Si no se encuentra atributo {@code alt}, se usa cadena vacía.
+     *
+     * @param description Texto a procesar (puede ser null)
+     * @return descripción con imágenes convertidas a sintaxis Markdown.
+     */
+    public static String normalizeImages(String description) {
+        if (description == null || description.isEmpty()) {
+            return description;
+        }
+
+        // Regex que captura src y alt opcional
+        String regex = "<img\\s+[^>]*src\\s*=\\s*\"([^\"]+)\"[^>]*>";
+        StringBuffer sb = new StringBuffer();
+
+        java.util.regex.Matcher matcher = java.util.regex.Pattern.compile(regex, java.util.regex.Pattern.CASE_INSENSITIVE)
+                .matcher(description);
+
+        while (matcher.find()) {
+            String imgTag = matcher.group();
+            String src = matcher.group(1);
+
+            // Extraer alt si existe
+            String alt = "";
+            java.util.regex.Matcher altMatcher = java.util.regex.Pattern.compile("alt\\s*=\\s*\"([^\"]+)\"", java.util.regex.Pattern.CASE_INSENSITIVE)
+                    .matcher(imgTag);
+            if (altMatcher.find()) {
+                alt = altMatcher.group(1);
+            }
+
+            String replacement = "![" + alt + "](" + src + ")";
+            matcher.appendReplacement(sb, java.util.regex.Matcher.quoteReplacement(replacement));
+        }
+
+        matcher.appendTail(sb);
+        return sb.toString();
+    }    
 }

--- a/src/main/java/io/github/philbone/javadocmd/extractor/README.md
+++ b/src/main/java/io/github/philbone/javadocmd/extractor/README.md
@@ -85,3 +85,17 @@ public class JavadocUtils
 > Devuelve la "descripción completa" del Javadoc, incluyendo los block tags
 > en forma textual, pero ignorando {@code @project}.
 
+- `public static`[String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `normalizeImages(String description)`
+> Normaliza etiquetas HTML de imagen dentro de una descripción Javadoc.
+> <p>
+> Convierte etiquetas <img> en sintaxis Markdown:
+> <pre>{@code
+> ![Diagrama](docs/diagrama.png)
+> →
+> ![Diagrama](docs/diagrama.png)
+> }</pre>
+> 
+> Si no se encuentra atributo {@code alt}, se usa cadena vacía.
+
+> - *@param* **description** Texto a procesar (puede ser null)
+> - *@return* descripción con imágenes convertidas a sintaxis Markdown.

--- a/src/test/java/NormalizeImagesTest.java
+++ b/src/test/java/NormalizeImagesTest.java
@@ -1,0 +1,63 @@
+
+import io.github.philbone.javadocmd.extractor.JavadocUtils;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ *
+ * @author felipe
+ */
+public class NormalizeImagesTest
+{
+    
+    @Test
+    void normalizeImages_debeConvertirImgConAlt() {
+        String input = "Diagrama general: <img src=\"img/diagram.png\" alt=\"Diagrama del sistema\">";
+        String expected = "Diagrama general: ![Diagrama del sistema](img/diagram.png)";
+        assertEquals(expected, JavadocUtils.normalizeImages(input));
+    }
+
+    @Test
+    void normalizeImages_debeConvertirImgSinAlt() {
+        String input = "Ejemplo: <img src=\"docs/example.png\">";
+        String expected = "Ejemplo: ![](docs/example.png)";
+        assertEquals(expected, JavadocUtils.normalizeImages(input));
+    }
+
+    @Test
+    void normalizeImages_noDebeAlterarTextoSinImg() {
+        String input = "Texto sin imágenes";
+        assertEquals(input, JavadocUtils.normalizeImages(input));
+    }
+
+    @Test
+    void normalizeImages_debeConvertirMultiplesImg() {
+        String input = "Primera <img src=\"a.png\" alt=\"A\"> y segunda <img src=\"b.png\">";
+        String expected = "Primera ![A](a.png) y segunda ![](b.png)";
+        assertEquals(expected, JavadocUtils.normalizeImages(input));
+    }
+    
+     @Test
+    void normalizeImages_debeConvertirEtiquetasImgHttpYHttps() {
+        // given
+        String input = """
+            Esta es una prueba con imágenes:
+            <img src="http://example.com/uno.png" alt="Uno">
+            <img src="https://cdn.example.com/dos.jpg">
+            Texto final.
+            """;
+
+        // when
+        String output = JavadocUtils.normalizeImages(input);
+
+        // then
+        assertTrue(output.contains("![Uno](http://example.com/uno.png)"),
+                "Debe convertir la imagen con atributo alt en Markdown");
+        assertTrue(output.contains("![](https://cdn.example.com/dos.jpg)"),
+                "Debe convertir la imagen sin atributo alt correctamente");
+        assertTrue(output.startsWith("Esta es una prueba"),
+                "Debe conservar el texto anterior a las imágenes");
+        assertTrue(output.endsWith("Texto final."),
+                "Debe conservar el texto posterior a las imágenes");
+    }
+}


### PR DESCRIPTION
…arkdown

- Se agregó el método JavadocUtils.normalizeImages() para detectar etiquetas <img> en el texto Javadoc y convertirlas automáticamente a formato Markdown ![alt](url).
- Se integró la normalización dentro de MarkdownExporter para aplicar el cambio a descripciones de clases, métodos y campos.
- Se añadió test unitario para validar enlaces con http y https.
- Mejora la compatibilidad con documentación visual embebida.

close #39