### PR TITLE
feat(config): agregar opción para generar documentación combinada o p…

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -3,4 +3,5 @@
 sourcePath: "/home/felipe/Documentos/proyectos/Java/javadocmd/src/main/java/io/github/philbone/javadocmd/"
 outputPath: "/home/felipe/Documentos/proyectos/Java/javadocmd/src/main/java/"
 outFileName: "README.md"
+combinePackagesMode: false
 debugMode: false

--- a/src/main/java/io/github/philbone/javadocmd/README.md
+++ b/src/main/java/io/github/philbone/javadocmd/README.md
@@ -52,7 +52,7 @@ public abstract class JavadocMd
 > - *@param* **args** argumentos opcionales (no utilizados actualmente). Se planea
 en futuras versiones aceptar <code>sourcePath</code> y
 <code>outputPath</code> como parámetros desde consola.
-- `public static` **void** `generateDocs(String sourcePath, String outputPath, String outFileName)`
+- `public static` **void** `generatePackageDocs(String sourcePath, String outputPath, String outFileName)`
 > Genera la documentación en formato Markdown a partir del código fuente de
 > un proyecto Java.
 > <p>
@@ -73,4 +73,11 @@ Java a documentar.
 > - *@param* **outputPath** ruta del directorio donde se guardará la documentación
 generada. Si es <code>null</code> o vacío, la documentación se imprime en
 consola.
+- `private static` **void** `generateDocsSingle(String sourcePath, String outputPath, String outFileName)`
+> generateDocs(String sourcePath, String outputPath, String outFileName)
+
+> - *@param* **sourcePath** 
+> - *@param* **outputPath** 
+> - *@param* **outFileName** 
+- `public static` **void** `generateCombinedDocs(String sourcePath, String outputPath, String outFileName)`
 - `public static` **void** `forceJavaLevel(ParserConfiguration.LanguageLevel languageLevel)`

--- a/src/main/java/io/github/philbone/javadocmd/config/Config.java
+++ b/src/main/java/io/github/philbone/javadocmd/config/Config.java
@@ -27,6 +27,13 @@ public class Config
      * Bandera de depuración para imprimir trazas adicionales.
      */
     private boolean debugMode;
+    
+    /**
+     * Bandera para definir el modo de exportación
+     * false exportar un fichero por cada paquete
+     * true exportar un fichero de forma global.
+     */
+    private boolean combinePackagesMode;
 
     // Constructor con valores por defecto
     public Config() {
@@ -98,4 +105,22 @@ public class Config
     public void setDebugMode(boolean debugMode) {
         this.debugMode = debugMode;
     }
+    
+    /**
+     * 
+     * @return
+     */
+    public boolean isCombinePackagesMode() {
+        return combinePackagesMode;
+    }
+    
+    /**
+     * 
+     * @param multiFileMode 
+     */
+    public void setCombinePackagesMode(boolean combinePackages) {
+        this.combinePackagesMode = combinePackages;
+    }
+    
+    
 }

--- a/src/main/java/io/github/philbone/javadocmd/config/README.md
+++ b/src/main/java/io/github/philbone/javadocmd/config/README.md
@@ -7,7 +7,7 @@
 
 |CLASE|DESCRIPCIÓN|
 |---|---|
-|[public class ConfigLoader](#-public-class-configloader)|Esta clase se encarga de cargar el fichero de configuración
+|[public class ConfigLoader](#-public-class-configloader)|Esta clase se encarga de detectar el fichero de configuración y cargar los datos si son encontrados.
 |[public class Config](#-public-class-config)|
 ## 📘 Public Class ConfigLoader
 
@@ -15,7 +15,9 @@
 public class ConfigLoader
 ```
 > **Descripción:**
-> Esta clase se encarga de cargar el fichero de configuración
+> Esta clase se encarga de detectar el fichero de configuración
+> y cargar los datos si son encontrados.
+> De otra manera cargará los valores por defecto.
 
 ### 🧮 Métodos
 
@@ -41,6 +43,11 @@ public class Config
 - `private` boolean `debugMode`
 > Bandera de depuración para imprimir trazas adicionales.
 
+- `private` boolean `combinePackagesMode`
+> Bandera para definir el modo de exportación
+> false exportara un fichero por cada paquete
+> true exportara un fichero de forma global.
+
 ### 🛠️ Constructores
 
 - `public Config()`
@@ -64,3 +71,7 @@ public class Config
 > - *@return* 
 - `public` **void** `setDebugMode(boolean debugMode)`
 > - *@param* **debugMode** 
+- `public`boolean `isCombinePackagesMode()`
+> - *@return* 
+- `public` **void** `setCombinePackagesMode(boolean combinePackages)`
+> - *@param* **multiFileMode** 


### PR DESCRIPTION
…or paquete

- Se agregó el parámetro `combinePackages` al archivo de configuración YAML.
- Se reemplazaron los métodos ambiguos `generateDocs()` y `generateDocsMulti()` por:
  - `generatePackageDocs()` → genera un archivo por paquete.
  - `generateCombinedDocs()` → combina toda la documentación en un único archivo.
- Se actualizó el flujo principal (`main`) para seleccionar automáticamente el modo según la configuración.

close: #19  decidir si se generan varios archivos o uno solo