### PR TITLE
feat(config): Agrega soporte para manejar la visibilidad del índice

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -24,3 +24,5 @@ includePublic: true
 
 # true/false: activa/desactiva el modo de depuración
 debugMode: false
+
+tableOfContent: true

--- a/src/main/java/io/github/philbone/javadocmd/README.md
+++ b/src/main/java/io/github/philbone/javadocmd/README.md
@@ -37,7 +37,13 @@ public abstract class JavadocMd
 
 ### 🛠️ Constructores
 
-> _No hay constructores visibles_
+- `protected JavadocMd()`
+> **Descripción:**
+> Constructor protegido por defecto.
+> <p>
+> Inicializa valores de configuración básicos.
+
+> - *@throws* **IllegalStateException** si la configuración inicial es inválida.
 ### 🧮 Métodos
 
 - `public  static` **void** `main(String[] args)`

--- a/src/main/java/io/github/philbone/javadocmd/config/Config.java
+++ b/src/main/java/io/github/philbone/javadocmd/config/Config.java
@@ -38,7 +38,9 @@ public class Config
     private boolean includePrivate;
     private boolean includeProtected;
     private boolean includePublic;
-
+    
+    private boolean tableOfContent;
+    
     // Constructor con valores por defecto
     public Config() {
         this.sourcePath = "/src";
@@ -46,6 +48,7 @@ public class Config
         //this.outFileName = "README.md";
         this.debugMode = false;
         this.combinePackagesMode = false;
+        this.tableOfContent = true;
     }
 
     /**
@@ -122,7 +125,7 @@ public class Config
     
     /**
      * 
-     * @param multiFileMode 
+     * @param combinePackages  
      */
     public void setCombinePackagesMode(boolean combinePackages) {
         this.combinePackagesMode = combinePackages;
@@ -151,8 +154,13 @@ public class Config
     public void setIncludePublic(boolean includePublic) {
         this.includePublic = includePublic;
     }
-    
-    
-    
+
+    public boolean isTableOfContent() {
+        return tableOfContent;
+    }
+
+    public void setTableOfContent(boolean tableOfContent) {
+        this.tableOfContent = tableOfContent;
+    }
     
 }

--- a/src/main/java/io/github/philbone/javadocmd/config/README.md
+++ b/src/main/java/io/github/philbone/javadocmd/config/README.md
@@ -51,6 +51,7 @@ public class Config
 - `private` boolean `includePrivate`
 - `private` boolean `includeProtected`
 - `private` boolean `includePublic`
+- `private` boolean `tableOfContent`
 ### 🛠️ Constructores
 
 - `public Config()`
@@ -77,10 +78,12 @@ public class Config
 - `public `boolean `isCombinePackagesMode()`
 > - *@return* 
 - `public ` **void** `setCombinePackagesMode(boolean combinePackages)`
-> - *@param* **multiFileMode** 
+> - *@param* **combinePackages** 
 - `public `boolean `isIncludePrivate()`
 - `public ` **void** `setIncludePrivate(boolean includePrivate)`
 - `public `boolean `isIncludeProtected()`
 - `public ` **void** `setIncludeProtected(boolean includeProtected)`
 - `public `boolean `isIncludePublic()`
 - `public ` **void** `setIncludePublic(boolean includePublic)`
+- `public `boolean `isTableOfContent()`
+- `public ` **void** `setTableOfContent(boolean tableOfContent)`

--- a/src/main/java/io/github/philbone/javadocmd/exporter/MarkdownExporter.java
+++ b/src/main/java/io/github/philbone/javadocmd/exporter/MarkdownExporter.java
@@ -46,7 +46,9 @@ public class MarkdownExporter implements DocExporter
         builder.subtitle(docPackage.getName());
 
         // TOC
-        builder.toc(docPackage);
+        if (config.isTableOfContent()) {
+            builder.toc(docPackage);
+        }
 
         // Determinar si se deben colapsar las clases
         boolean collapseClasses = docPackage.getClasses().size() > COLLAPSE_THRESHOLD;


### PR DESCRIPTION
- Agrega el parámetro tableOfContent para manejar la visibilidad del índice desde el fichero de configuración.
- Modifica la clase Config para soportar tableOfContent.
- Implementa la nueva característica en la clase MarkdownExporter

close: #37