### PR TITLE
fix(exporter): corrige inicialización de InternalLinker para vincular clases internas correctamente

### DIFF
--- a/src/main/java/io/github/philbone/javadocmd/README.md
+++ b/src/main/java/io/github/philbone/javadocmd/README.md
@@ -30,34 +30,6 @@ public abstract class JavadocMd
 > Actualmente soporta la exportación de documentación hacia un archivo
 > <code>README.md</code> por cada paquete encontrado en el proyecto.</p>
 
-### 📦 Campos
-
-<details open><summary>Public</summary>
-
-> _No hay campos public visibles_
-</details>
-
-<details open><summary>Protected</summary>
-
-> _No hay campos protected visibles_
-</details>
-
-<details open><summary>Private</summary>
-
-- `private static` int `executionCount`
-> Contador global de ejecuciones del generador de documentación.
-
-</details>
-
-### 🛠️ Constructores
-
-- `protected JavadocMd()`
-> **Descripción:**
-> Constructor protegido por defecto.
-> <p>
-> Inicializa valores de configuración básicos.
-
-> - *@throws* **IllegalStateException** si la configuración inicial es inválida.
 ### 🧮 Métodos
 
 <details open><summary>Public</summary>
@@ -81,5 +53,33 @@ en futuras versiones aceptar <code>sourcePath</code> y
 <details open><summary>Private</summary>
 
 > _No hay métodos private visibles_
+</details>
+
+### 🛠️ Constructores
+
+- `protected JavadocMd()`
+> **Descripción:**
+> Constructor protegido por defecto.
+> <p>
+> Inicializa valores de configuración básicos.
+
+> - *@throws* **IllegalStateException** si la configuración inicial es inválida.
+### 📦 Campos
+
+<details open><summary>Public</summary>
+
+> _No hay campos public visibles_
+</details>
+
+<details open><summary>Protected</summary>
+
+> _No hay campos protected visibles_
+</details>
+
+<details open><summary>Private</summary>
+
+- `private static` int `executionCount`
+> Contador global de ejecuciones del generador de documentación.
+
 </details>
 

--- a/src/main/java/io/github/philbone/javadocmd/config/README.md
+++ b/src/main/java/io/github/philbone/javadocmd/config/README.md
@@ -8,7 +8,7 @@
 |#|CLASE|DESCRIPCIÓN|
 |---|---|---|
 |**1**|[public class ConfigLoader](#1-public-class-configloader)|Esta clase se encarga de detectar el fichero de configuración y cargar los datos si son encontrados.
-|**2**|[public class Config](#2-public-class-config)|
+|**2**|[public class Config](#2-public-class-config)|@author Felipe M.
 ## #1 📘 Public Class ConfigLoader
 
 ```java
@@ -23,7 +23,7 @@ public class ConfigLoader
 
 <details open><summary>Public</summary>
 
-- `public  static`Config `loadConfig()`
+- `public  static`[Config](Config.md) `loadConfig()`
 > - *@return* un objeto con los datos de configuracion iniciales.
 </details>
 
@@ -42,52 +42,9 @@ public class ConfigLoader
 ```java
 public class Config
 ```
-### 📦 Campos
+> **Descripción:**
+> @author Felipe M. <philbone@focused.cl>
 
-<details open><summary>Public</summary>
-
-> _No hay campos public visibles_
-</details>
-
-<details open><summary>Protected</summary>
-
-> _No hay campos protected visibles_
-</details>
-
-<details open><summary>Private</summary>
-
-- `private` [String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `sourcePath`
-> Directorio de entrada donde se encuentran las clases a documentar. *
-
-- `private` [String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `outputPath`
-> Directorio base donde se escribirá la documentación generada.
-
-- `private` [String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `outFileName`
-> Nombre del archivo de salida que contendrá la documentación en cada
-> paquete.
-
-- `private` boolean `debugMode`
-> Bandera de depuración para imprimir trazas adicionales.
-
-- `private` boolean `combinePackagesMode`
-> Bandera para definir el modo de exportación
-> false exportar un fichero por cada paquete
-> true exportar un fichero de forma global.
-
-- `private` boolean `includePrivate`
-- `private` boolean `includeProtected`
-- `private` boolean `includePublic`
-- `private` boolean `tableOfContent`
-- `private` boolean `printEmptyNotify`
-- `private` boolean `printClassIndex`
-- `private` [String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `foreSignClassIndex`
-- `private` boolean `foreSignClassIndexOnDetails`
-- `private` boolean `foreSignClassIndexOnSubtitle`
-</details>
-
-### 🛠️ Constructores
-
-- `public Config()`
 ### 🧮 Métodos
 
 <details open><summary>Public</summary>
@@ -142,5 +99,51 @@ public class Config
 <details open><summary>Private</summary>
 
 > _No hay métodos private visibles_
+</details>
+
+### 🛠️ Constructores
+
+- `public Config()`
+### 📦 Campos
+
+<details open><summary>Public</summary>
+
+> _No hay campos public visibles_
+</details>
+
+<details open><summary>Protected</summary>
+
+> _No hay campos protected visibles_
+</details>
+
+<details open><summary>Private</summary>
+
+- `private` [String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `sourcePath`
+> Directorio de entrada donde se encuentran las clases a documentar. *
+
+- `private` [String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `outputPath`
+> Directorio base donde se escribirá la documentación generada.
+
+- `private` [String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `outFileName`
+> Nombre del archivo de salida que contendrá la documentación en cada
+> paquete.
+
+- `private` boolean `debugMode`
+> Bandera de depuración para imprimir trazas adicionales.
+
+- `private` boolean `combinePackagesMode`
+> Bandera para definir el modo de exportación
+> false exportar un fichero por cada paquete
+> true exportar un fichero de forma global.
+
+- `private` boolean `includePrivate`
+- `private` boolean `includeProtected`
+- `private` boolean `includePublic`
+- `private` boolean `tableOfContent`
+- `private` boolean `printEmptyNotify`
+- `private` boolean `printClassIndex`
+- `private` [String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `foreSignClassIndex`
+- `private` boolean `foreSignClassIndexOnDetails`
+- `private` boolean `foreSignClassIndexOnSubtitle`
 </details>
 

--- a/src/main/java/io/github/philbone/javadocmd/exporter/InternalLinker.java
+++ b/src/main/java/io/github/philbone/javadocmd/exporter/InternalLinker.java
@@ -1,0 +1,115 @@
+package io.github.philbone.javadocmd.exporter;
+
+import java.util.*;
+
+/**
+ * InternalLinker: convierte nombres de tipo en enlaces internos a la
+ * documentación generada por JavadocMd.
+ *
+ * - Soporta tipos simples y FQCNs.
+ * - Normaliza genéricos y arrays: List<Config> -> Config
+ * - Mapea simpleName -> fqn(s) para búsquedas rápidas.
+ */
+public class InternalLinker {
+
+    private final Set<String> internalClasses; // puede ser FQCNs o simples, según cómo lo inicialices
+    private final Map<String, List<String>> simpleToFqns;
+    private final String extension;
+    private final boolean debug;
+
+    public InternalLinker(Set<String> internalClasses, String extension) {
+        this(internalClasses, extension, false);
+    }
+
+    public InternalLinker(Set<String> internalClasses, String extension, boolean debug) {
+        this.internalClasses = new HashSet<>();
+        this.simpleToFqns = new HashMap<>();
+        this.extension = extension.startsWith(".") ? extension : "." + extension;
+        this.debug = debug;
+
+        // Normalizar el set recibido y construir mapa simpleName -> fqn(s).
+        for (String raw : internalClasses) {
+            if (raw == null || raw.isBlank()) continue;
+            String s = raw.trim();
+            this.internalClasses.add(s); // mantengo la forma original (puede ser "Config" o "io.x.y.Config")
+
+            String simple = extractSimpleName(s);
+            simpleToFqns.computeIfAbsent(simple, k -> new ArrayList<>()).add(s);
+
+            if (debug) {
+                System.err.println(">> InternalLinker registered: [" + s + "] as simpleName [" + simple + "]");
+            }
+        }
+    }
+
+    /**
+     * Devuelve un enlace Markdown si el tipo pertenece al proyecto JavadocMd.
+     * Si no hay coincidencia, retorna null.
+     */
+    public String linkIfInternalType(String typeName) {
+        if (typeName == null || typeName.isBlank()) {
+            return null;
+        }
+
+        if (debug) {
+            System.err.println(">> [linkIfInternalType] buscando coincidencia exacta para: " + typeName);
+        }
+
+        for (String internal : internalClasses) {
+            if (internal.equals(typeName) || internal.endsWith("." + typeName)) {
+                if (debug) {
+                    System.err.println(">> [linkIfInternalType] MATCH encontrado: " + internal);
+                }
+                return buildLink(internal);
+            }
+        }
+
+        if (debug) {
+            System.err.println(">> [linkIfInternalType] sin coincidencia: " + typeName);
+        }
+        return null;
+        // Nota técnica:
+        // Se eliminó la versión anterior con normalización y mapas de búsqueda
+        // porque en proyectos pequeños (como JavadocMd) bastaba con una coincidencia
+        // simple o por sufijo. Además, la versión anterior causaba falsos negativos
+        // cuando el InternalLinker se instanciaba por paquete.
+    }
+
+    private String normalizeTypeName(String raw) {
+        String s = raw.trim();
+        // eliminar genéricos complejos (usa reluctant)
+        s = s.replaceAll("<.*?>", "");
+        // eliminar arrays
+        s = s.replace("[]", "");
+        // eliminar espacios redundantes
+        s = s.trim();
+        return s;
+    }
+
+    private String extractSimpleName(String fqnOrSimple) {
+        int idx = fqnOrSimple.lastIndexOf('.');
+        if (idx >= 0 && idx < fqnOrSimple.length() - 1) {
+            return fqnOrSimple.substring(idx + 1);
+        } else {
+            return fqnOrSimple;
+        }
+    }
+
+    private String buildLink(String fqn) {
+        // Si fqn contiene puntos -> asumimos FQCN y construimos ruta completa
+        String path;
+        if (fqn.contains(".")) {
+            path = fqn.replace('.', '/') + extension;
+        } else {
+            // Si solo es simpleName, lo dejamos relativo al mismo directorio
+            path = fqn + extension;
+        }
+        String simpleName = extractSimpleName(fqn);
+        if (debug) System.err.println(">> buildLink: fqn=" + fqn + " -> path=" + path);
+        return String.format("[%s](%s)", simpleName, path);
+    }
+
+    public int size() {
+        return this.internalClasses.size();
+    }
+}

--- a/src/main/java/io/github/philbone/javadocmd/exporter/README.md
+++ b/src/main/java/io/github/philbone/javadocmd/exporter/README.md
@@ -10,7 +10,11 @@
 |**1**|[public interface DocExporter](#1-public-interface-docexporter)|
 |**2**|[public class MarkdownExporter](#2-public-class-markdownexporter)|Exportador que genera documentación en formato Markdown a partir del modelo intermedio construido con {@link io.
 |**3**|[public class MarkdownBuilder](#3-public-class-markdownbuilder)|
-|**4**|[public class JavaApiLinker](#4-public-class-javaapilinker)|Utilidad para convertir nombres de tipos de Java en enlaces a la documentación oficial de la API de Java SE.
+|**4**|[public class InternalLinker](#4-public-class-internallinker)|InternalLinker: convierte nombres de tipo en enlaces internos a la documentación generada por JavadocMd.
+|**5**|[public class JavaApiLinker](#5-public-class-javaapilinker)|Utilidad para convertir nombres de tipos de Java en enlaces a la documentación oficial de la API de Java SE.
+<details>
+<summary> <strong> 📗 Public Interface DocExporter</strong> </summary>
+
 ## #1 📗 Public Interface DocExporter
 
 ```java
@@ -33,6 +37,11 @@ public interface DocExporter
 > _No hay métodos private visibles_
 </details>
 
+
+</details>
+<details>
+<summary> <strong> 📘 Public Class MarkdownExporter</strong> </summary>
+
 ## #2 📘 Public Class MarkdownExporter
 
 ```java
@@ -52,36 +61,6 @@ implements DocExporter
 >     <li>Campos, constructores y métodos con sus firmas y documentación Javadoc.</li>
 > </ul>
 
-### 📦 Campos
-
-<details open><summary>Public</summary>
-
-> _No hay campos public visibles_
-</details>
-
-<details open><summary>Protected</summary>
-
-> _No hay campos protected visibles_
-</details>
-
-<details open><summary>Private</summary>
-
-- `private static` int `COLLAPSE_THRESHOLD`
-> Número mínimo de clases dentro de un paquete para activar el modo colapsable.
-> Si el paquete tiene más de este número, cada clase se renderiza dentro de un bloque `<details>`.
-
-- `private static` [String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `VISIBILITY_PUBLIC`
-- `private static` [String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `VISIBILITY_PRIVATE`
-- `private static` [String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `VISIBILITY_PROTECTED`
-- `private` Config `config`
-- `private` int `totalMethodsCount`
-- `private` int `totalFieldsCount`
-- `private` JavaApiLinker `apiLinker`
-</details>
-
-### 🛠️ Constructores
-
-- `public MarkdownExporter(Config config)`
 ### 🧮 Métodos
 
 <details open><summary>Public</summary>
@@ -112,11 +91,9 @@ implements DocExporter
 - `private `[String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `printIndexNumber(int indexOrder, boolean foreSign)`
 </details>
 
-## #3 📘 Public Class MarkdownBuilder
+### 🛠️ Constructores
 
-```java
-public class MarkdownBuilder
-```
+- `public MarkdownExporter(Config config, InternalLinker internalLinker)`
 ### 📦 Campos
 
 <details open><summary>Public</summary>
@@ -131,23 +108,45 @@ public class MarkdownBuilder
 
 <details open><summary>Private</summary>
 
-- `private` StringBuilder `outPrint`
+- `private static` int `COLLAPSE_THRESHOLD`
+> Número mínimo de clases dentro de un paquete para activar el modo colapsable.
+> Si el paquete tiene más de este número, cada clase se renderiza dentro de un bloque `<details>`.
+
+- `private static` [String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `VISIBILITY_PUBLIC`
+- `private static` [String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `VISIBILITY_PRIVATE`
+- `private static` [String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `VISIBILITY_PROTECTED`
+- `private` [Config](Config.md) `config`
+- `private` int `totalMethodsCount`
+- `private` int `totalFieldsCount`
+- `private` [JavaApiLinker](JavaApiLinker.md) `apiLinker`
+- `private` [InternalLinker](InternalLinker.md) `internalLinker`
+- `private` [DocPackage](DocPackage.md) `docPackage`
 </details>
 
+
+</details>
+<details>
+<summary> <strong> 📘 Public Class MarkdownBuilder</strong> </summary>
+
+## #3 📘 Public Class MarkdownBuilder
+
+```java
+public class MarkdownBuilder
+```
 ### 🧮 Métodos
 
 <details open><summary>Public</summary>
 
-- `public `MarkdownBuilder `title(String text)`
-- `public `MarkdownBuilder `subtitle(String text)`
-- `public `MarkdownBuilder `h3(String text)`
-- `public `MarkdownBuilder `h4(String text)`
-- `public `MarkdownBuilder `paragraph(String text)`
-- `public `MarkdownBuilder `listItem(String text)`
+- `public `[MarkdownBuilder](MarkdownBuilder.md) `title(String text)`
+- `public `[MarkdownBuilder](MarkdownBuilder.md) `subtitle(String text)`
+- `public `[MarkdownBuilder](MarkdownBuilder.md) `h3(String text)`
+- `public `[MarkdownBuilder](MarkdownBuilder.md) `h4(String text)`
+- `public `[MarkdownBuilder](MarkdownBuilder.md) `paragraph(String text)`
+- `public `[MarkdownBuilder](MarkdownBuilder.md) `listItem(String text)`
 - `public `[String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `build()`
 - `public ` **void** `codeBlock(String content, String codeLang)`
-- `public `MarkdownBuilder `blockquote(String text)`
-- `public `MarkdownBuilder `tag(String tag)`
+- `public `[MarkdownBuilder](MarkdownBuilder.md) `blockquote(String text)`
+- `public `[MarkdownBuilder](MarkdownBuilder.md) `tag(String tag)`
 > Inyecta una etiqueta arbitraria directamente en el flujo del Markdown.
 > <p>
 > Se utiliza principalmente como auxiliar para aplicar prefijos en las
@@ -167,8 +166,8 @@ public class MarkdownBuilder
 buffer).
 > - *@return* la instancia actual de {@code MarkdownBuilder}, para encadenar
 llamadas.
-- `public `MarkdownBuilder `toc(DocPackage docPackage)`
-- `public `MarkdownBuilder `insertAt(int index, String text)`
+- `public `[MarkdownBuilder](MarkdownBuilder.md) `toc(DocPackage docPackage)`
+- `public `[MarkdownBuilder](MarkdownBuilder.md) `insertAt(int index, String text)`
 </details>
 
 <details open><summary>Protected</summary>
@@ -181,7 +180,94 @@ llamadas.
 - `private `[String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `sanitizeDescription(String raw)`
 </details>
 
-## #4 📘 Public Class JavaApiLinker
+### 📦 Campos
+
+<details open><summary>Public</summary>
+
+> _No hay campos public visibles_
+</details>
+
+<details open><summary>Protected</summary>
+
+> _No hay campos protected visibles_
+</details>
+
+<details open><summary>Private</summary>
+
+- `private` StringBuilder `outPrint`
+</details>
+
+
+</details>
+<details>
+<summary> <strong> 📘 Public Class InternalLinker</strong> </summary>
+
+## #4 📘 Public Class InternalLinker
+
+```java
+public class InternalLinker
+```
+> **Descripción:**
+> InternalLinker: convierte nombres de tipo en enlaces internos a la
+> documentación generada por JavadocMd.
+> 
+> - Soporta tipos simples y FQCNs.
+> - Normaliza genéricos y arrays: List<Config> -> Config
+> - Mapea simpleName -> fqn(s) para búsquedas rápidas.
+
+### 🧮 Métodos
+
+<details open><summary>Public</summary>
+
+- `public `[String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `linkIfInternalType(String typeName)`
+> Devuelve un enlace Markdown si el tipo pertenece al proyecto JavadocMd.
+> Si no hay coincidencia, retorna null.
+
+- `public `int `size()`
+</details>
+
+<details open><summary>Protected</summary>
+
+> _No hay métodos protected visibles_
+</details>
+
+<details open><summary>Private</summary>
+
+- `private `[String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `normalizeTypeName(String raw)`
+- `private `[String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `extractSimpleName(String fqnOrSimple)`
+- `private `[String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `buildLink(String fqn)`
+</details>
+
+### 🛠️ Constructores
+
+- `public InternalLinker(Set<String> internalClasses, String extension)`
+- `public InternalLinker(Set<String> internalClasses, String extension, boolean debug)`
+### 📦 Campos
+
+<details open><summary>Public</summary>
+
+> _No hay campos public visibles_
+</details>
+
+<details open><summary>Protected</summary>
+
+> _No hay campos protected visibles_
+</details>
+
+<details open><summary>Private</summary>
+
+- `private` [Set](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/Set.html)<String> `internalClasses`
+- `private` [Map](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/Map.html)<String,List<String>> `simpleToFqns`
+- `private` [String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `extension`
+- `private` boolean `debug`
+</details>
+
+
+</details>
+<details>
+<summary> <strong> 📘 Public Class JavaApiLinker</strong> </summary>
+
+## #5 📘 Public Class JavaApiLinker
 
 ```java
 public class JavaApiLinker
@@ -195,6 +281,39 @@ public class JavaApiLinker
 > JavaApiLinker.linkIfJavaType("List<String>");
 > // → [List](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/List.html)<String>
 > }</pre>
+
+### 🧮 Métodos
+
+<details open><summary>Public</summary>
+
+- `public  static`[String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `linkIfJavaType(String type)`
+> Si el tipo pertenece al paquete estándar de Java (java.* o javax.*),
+> devuelve un enlace Markdown al Javadoc oficial.
+> De lo contrario, devuelve el tipo original sin enlace.
+
+> - *@param* **type** 
+> - *@return* 
+</details>
+
+<details open><summary>Protected</summary>
+
+> _No hay métodos protected visibles_
+</details>
+
+<details open><summary>Private</summary>
+
+- `private  static`[String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `fqcnToUrl(String fqcn)`
+> Convierte un nombre de clase totalmente calificado en URL al Javadoc.
+
+- `private  static`[String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `determineModule(String pkg)`
+> Determina el módulo de Java donde reside un paquete.
+> Esto cubre los módulos más usados en Java SE 17.
+
+- `private  static`[String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `resolveToFQCN(String type)`
+> Intenta mapear un tipo simple (como "List") a su nombre de clase completo.
+> Solo incluye clases comunes de la API estándar.
+
+</details>
 
 ### 📦 Campos
 
@@ -218,34 +337,5 @@ public class JavaApiLinker
 
 </details>
 
-### 🧮 Métodos
-
-<details open><summary>Public</summary>
-
-- `public  static`[String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `linkIfJavaType(String type)`
-> Si el tipo pertenece al paquete estándar de Java (java.* o javax.*),
-> devuelve un enlace Markdown al Javadoc oficial.
-> De lo contrario, devuelve el tipo original sin enlace.
 
 </details>
-
-<details open><summary>Protected</summary>
-
-> _No hay métodos protected visibles_
-</details>
-
-<details open><summary>Private</summary>
-
-- `private  static`[String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `fqcnToUrl(String fqcn)`
-> Convierte un nombre de clase totalmente calificado en URL al Javadoc.
-
-- `private  static`[String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `determineModule(String pkg)`
-> Determina el módulo de Java donde reside un paquete.
-> Esto cubre los módulos más usados en Java SE 17.
-
-- `private  static`[String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `resolveToFQCN(String type)`
-> Intenta mapear un tipo simple (como "List") a su nombre de clase completo.
-> Solo incluye clases comunes de la API estándar.
-
-</details>
-

--- a/src/main/java/io/github/philbone/javadocmd/extractor/JavadocExtractorVisitor.java
+++ b/src/main/java/io/github/philbone/javadocmd/extractor/JavadocExtractorVisitor.java
@@ -261,9 +261,10 @@ public class JavadocExtractorVisitor extends VoidVisitorAdapter<DocPackage>
         boolean isStatic = extractIsStatic(n);
 
         n.getVariables().forEach(var -> {
+            String type = n.getElementType().asString().trim(); // 👈 aseguramos el formato limpio
             DocField docField = new DocField(
                     var.getNameAsString(),
-                    n.getElementType().toString(),
+                    type,
                     description,
                     visibility,
                     isStatic
@@ -351,7 +352,7 @@ public class JavadocExtractorVisitor extends VoidVisitorAdapter<DocPackage>
         //    como último recurso (opcional). Aquí lo dejamos como no obligatorio.
         if (description == null || description.isEmpty()) {
             // opcional: comentar o activar según prefieras
-            // description = JavadocUtils.extractFullDescription(maybe);
+            description = JavadocUtils.extractFullDescription(maybe);
         }
 
         if (description != null && !description.isEmpty()) {

--- a/src/main/java/io/github/philbone/javadocmd/extractor/README.md
+++ b/src/main/java/io/github/philbone/javadocmd/extractor/README.md
@@ -76,23 +76,6 @@ public class JavadocUtils
 >   <li>obtener una "descripción completa" que incluye los block tags (útil para debugging / fallback).</li>
 > </ul>
 
-### 📦 Campos
-
-<details open><summary>Public</summary>
-
-> _No hay campos public visibles_
-</details>
-
-<details open><summary>Protected</summary>
-
-> _No hay campos protected visibles_
-</details>
-
-<details open><summary>Private</summary>
-
-- `private static` [List](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/List.html)<String> `TECHNICAL_TAGS`
-</details>
-
 ### 🧮 Métodos
 
 <details open><summary>Public</summary>
@@ -137,5 +120,22 @@ public class JavadocUtils
 <details open><summary>Private</summary>
 
 - `private  static`Javadoc `parseCleaning(JavadocComment comment)`
+</details>
+
+### 📦 Campos
+
+<details open><summary>Public</summary>
+
+> _No hay campos public visibles_
+</details>
+
+<details open><summary>Protected</summary>
+
+> _No hay campos protected visibles_
+</details>
+
+<details open><summary>Private</summary>
+
+- `private static` [List](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/List.html)<String> `TECHNICAL_TAGS`
 </details>
 

--- a/src/main/java/io/github/philbone/javadocmd/model/README.md
+++ b/src/main/java/io/github/philbone/javadocmd/model/README.md
@@ -10,7 +10,7 @@
 |**1**|[public class DocConstructor](#1-public-class-docconstructor)|Representa un constructor documentado dentro de una clase.
 |**2**|[public class DocClass](#2-public-class-docclass)|Representa la definición de una clase, interfaz, enum o record dentro del modelo intermedio de documentación.
 |**3**|[public class DocMethod](#3-public-class-docmethod)|
-|**4**|[public class DocParameter](#4-public-class-docparameter)|
+|**4**|[public class DocParameter](#4-public-class-docparameter)|@author Felipe M.
 |**5**|[public class DocPackage](#5-public-class-docpackage)|Representa un paquete de Java dentro del modelo intermedio de documentación.
 |**6**|[public enum Kind](#6-public-enum-kind)|
 |**7**|[public class DocException](#7-public-class-docexception)|
@@ -26,32 +26,6 @@ public class DocConstructor
 > **Descripción:**
 > Representa un constructor documentado dentro de una clase.
 
-### 📦 Campos
-
-<details open><summary>Public</summary>
-
-> _No hay campos public visibles_
-</details>
-
-<details open><summary>Protected</summary>
-
-> _No hay campos protected visibles_
-</details>
-
-<details open><summary>Private</summary>
-
-- `private` [String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `name`
-- `private` [List](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/List.html)<String> `parameters`
-- `private` [String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `description`
-- `private` [String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `visibility`
-- `private` boolean `isStatic`
-- `private` [List](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/List.html)<DocParameter> `docParameters`
-- `private` [List](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/List.html)<DocException> `exceptions`
-</details>
-
-### 🛠️ Constructores
-
-- `public DocConstructor(String name, List<String> parameters, String description, String visibility, boolean isStatic)`
 ### 🧮 Métodos
 
 <details open><summary>Public</summary>
@@ -75,6 +49,32 @@ public class DocConstructor
 <details open><summary>Private</summary>
 
 > _No hay métodos private visibles_
+</details>
+
+### 🛠️ Constructores
+
+- `public DocConstructor(String name, List<String> parameters, String description, String visibility, boolean isStatic)`
+### 📦 Campos
+
+<details open><summary>Public</summary>
+
+> _No hay campos public visibles_
+</details>
+
+<details open><summary>Protected</summary>
+
+> _No hay campos protected visibles_
+</details>
+
+<details open><summary>Private</summary>
+
+- `private` [String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `name`
+- `private` [List](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/List.html)<String> `parameters`
+- `private` [String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `description`
+- `private` [String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `visibility`
+- `private` boolean `isStatic`
+- `private` [List](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/List.html)<DocParameter> `docParameters`
+- `private` [List](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/List.html)<DocException> `exceptions`
 </details>
 
 
@@ -103,66 +103,6 @@ public class DocClass
 > La información contenida en esta clase es utilizada por los exportadores (por ejemplo, {@code MarkdownExporter}) para generar documentación en distintos formatos.
 > </p>
 
-### 📦 Campos
-
-<details open><summary>Public</summary>
-
-> _No hay campos public visibles_
-</details>
-
-<details open><summary>Protected</summary>
-
-> _No hay campos protected visibles_
-</details>
-
-<details open><summary>Private</summary>
-
-- `private` int `indexOrder`
-> El número que tomará en la tabla de contenido
-
-- `private` [String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `name`
-> Nombre simple de la clase, interfaz, enum o record.
-
-- `private` Kind `kind`
-> Tipo de elemento representado (clase, interfaz, enum, record, abstracta).
-
-- `private` [String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `visibility`
-> Nivel de visibilidad del tipo (public, protected, package-private, private).
-
-- `private` boolean `isStatic`
-> Indica si el tipo ha sido declarado como {@code static}.
-
-- `private` [List](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/List.html)<DocField> `fields`
-> Campos declarados dentro de la clase.
-
-- `private` [List](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/List.html)<DocMethod> `methods`
-> Métodos declarados dentro de la clase.
-
-- `private` [List](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/List.html)<DocConstructor> `constructors`
-> Constructores declarados dentro de la clase.
-
-- `private` [String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `superClass`
-> Nombre de la clase padre (superclase), si existe.
-
-- `private` [List](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/List.html)<String> `interfaces`
-> Interfaces implementadas (clases) o extendidas (interfaces).
-
-- `private` [String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `description`
-> Descripción principal tomada del comentario Javadoc asociado.
-
-</details>
-
-### 🛠️ Constructores
-
-- `public DocClass(String name, String description, Kind kind, String visibility, boolean isStatic)`
-> **Descripción:**
-> Crea una nueva representación de clase en el modelo intermedio.
-
-> - *@param* `name` nombre simple de la clase
-> - *@param* `description` descripción principal (desde Javadoc)
-> - *@param* `kind` tipo del elemento (clase, interfaz, enum, record)
-> - *@param* `visibility` nivel de visibilidad (public, protected, package-private, private)
-> - *@param* `isStatic` indica si la clase fue declarada como {@code static}
 ### 🧮 Métodos
 
 <details open><summary>Public</summary>
@@ -171,7 +111,7 @@ public class DocClass
 > - *@return* el nombre simple de la clase.
 - `public `[String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `getDescription()`
 > - *@return* la descripción tomada del Javadoc.
-- `public `Kind `getKind()`
+- `public `[Kind](Kind.md) `getKind()`
 > - *@return* el tipo de elemento representado.
 - `public `[String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `getVisibility()`
 > - *@return* la visibilidad del tipo (public, protected, etc.).
@@ -222,16 +162,17 @@ public class DocClass
 > _No hay métodos private visibles_
 </details>
 
+### 🛠️ Constructores
 
-</details>
-<details>
-<summary> <strong> 📘 Public Class DocMethod</strong> </summary>
+- `public DocClass(String name, String description, Kind kind, String visibility, boolean isStatic)`
+> **Descripción:**
+> Crea una nueva representación de clase en el modelo intermedio.
 
-## #3 📘 Public Class DocMethod
-
-```java
-public class DocMethod
-```
+> - *@param* `name` nombre simple de la clase
+> - *@param* `description` descripción principal (desde Javadoc)
+> - *@param* `kind` tipo del elemento (clase, interfaz, enum, record)
+> - *@param* `visibility` nivel de visibilidad (public, protected, package-private, private)
+> - *@param* `isStatic` indica si la clase fue declarada como {@code static}
 ### 📦 Campos
 
 <details open><summary>Public</summary>
@@ -246,21 +187,51 @@ public class DocMethod
 
 <details open><summary>Private</summary>
 
+- `private` int `indexOrder`
+> El número que tomará en la tabla de contenido
+
 - `private` [String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `name`
-- `private` [String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `returnType`
-- `private` [List](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/List.html)<String> `parameters`
-- `private` [String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `description`
+> Nombre simple de la clase, interfaz, enum o record.
+
+- `private` [Kind](Kind.md) `kind`
+> Tipo de elemento representado (clase, interfaz, enum, record, abstracta).
+
 - `private` [String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `visibility`
+> Nivel de visibilidad del tipo (public, protected, package-private, private).
+
 - `private` boolean `isStatic`
-- `private` boolean `isVoid`
-- `private` [String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `returnDescription`
-- `private` [List](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/List.html)<DocParameter> `docParameters`
-- `private` [List](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/List.html)<DocException> `exceptions`
+> Indica si el tipo ha sido declarado como {@code static}.
+
+- `private` [List](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/List.html)<DocField> `fields`
+> Campos declarados dentro de la clase.
+
+- `private` [List](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/List.html)<DocMethod> `methods`
+> Métodos declarados dentro de la clase.
+
+- `private` [List](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/List.html)<DocConstructor> `constructors`
+> Constructores declarados dentro de la clase.
+
+- `private` [String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `superClass`
+> Nombre de la clase padre (superclase), si existe.
+
+- `private` [List](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/List.html)<String> `interfaces`
+> Interfaces implementadas (clases) o extendidas (interfaces).
+
+- `private` [String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `description`
+> Descripción principal tomada del comentario Javadoc asociado.
+
 </details>
 
-### 🛠️ Constructores
 
-- `public DocMethod(String name, String returnType, List<String> parameters, String description, String visibility, boolean isStatic, boolean isVoid)`
+</details>
+<details>
+<summary> <strong> 📘 Public Class DocMethod</strong> </summary>
+
+## #3 📘 Public Class DocMethod
+
+```java
+public class DocMethod
+```
 ### 🧮 Métodos
 
 <details open><summary>Public</summary>
@@ -290,16 +261,9 @@ public class DocMethod
 > _No hay métodos private visibles_
 </details>
 
+### 🛠️ Constructores
 
-</details>
-<details>
-<summary> <strong> 📘 Public Class DocParameter</strong> </summary>
-
-## #4 📘 Public Class DocParameter
-
-```java
-public class DocParameter
-```
+- `public DocMethod(String name, String returnType, List<String> parameters, String description, String visibility, boolean isStatic, boolean isVoid)`
 ### 📦 Campos
 
 <details open><summary>Public</summary>
@@ -315,12 +279,30 @@ public class DocParameter
 <details open><summary>Private</summary>
 
 - `private` [String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `name`
+- `private` [String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `returnType`
+- `private` [List](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/List.html)<String> `parameters`
 - `private` [String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `description`
+- `private` [String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `visibility`
+- `private` boolean `isStatic`
+- `private` boolean `isVoid`
+- `private` [String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `returnDescription`
+- `private` [List](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/List.html)<DocParameter> `docParameters`
+- `private` [List](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/List.html)<DocException> `exceptions`
 </details>
 
-### 🛠️ Constructores
 
-- `public DocParameter(String name, String description)`
+</details>
+<details>
+<summary> <strong> 📘 Public Class DocParameter</strong> </summary>
+
+## #4 📘 Public Class DocParameter
+
+```java
+public class DocParameter
+```
+> **Descripción:**
+> @author Felipe M. philbone@focused.cl
+
 ### 🧮 Métodos
 
 <details open><summary>Public</summary>
@@ -337,6 +319,27 @@ public class DocParameter
 <details open><summary>Private</summary>
 
 > _No hay métodos private visibles_
+</details>
+
+### 🛠️ Constructores
+
+- `public DocParameter(String name, String description)`
+### 📦 Campos
+
+<details open><summary>Public</summary>
+
+> _No hay campos public visibles_
+</details>
+
+<details open><summary>Protected</summary>
+
+> _No hay campos protected visibles_
+</details>
+
+<details open><summary>Private</summary>
+
+- `private` [String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `name`
+- `private` [String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `description`
 </details>
 
 
@@ -374,36 +377,6 @@ public class DocPackage
 > pkg.addClass(new DocClass("MarkdownExporter", "...", Kind.CLASS, "public", false));
 > }</pre>
 
-### 📦 Campos
-
-<details open><summary>Public</summary>
-
-> _No hay campos public visibles_
-</details>
-
-<details open><summary>Protected</summary>
-
-> _No hay campos protected visibles_
-</details>
-
-<details open><summary>Private</summary>
-
-- `private` [String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `name`
-> Nombre completo del paquete (ejemplo: {@code io.github.philbone.javadocmd.exporter}).
-
-- `private` [List](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/List.html)<DocClass> `classes`
-> Conjunto de clases, interfaces, enums y records pertenecientes al paquete.
-
-- `private` [String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `projectName`
-</details>
-
-### 🛠️ Constructores
-
-- `public DocPackage(String name)`
-> **Descripción:**
-> Crea un nuevo descriptor de paquete.
-
-> - *@param* `name` nombre del paquete en notación estándar de Java.
 ### 🧮 Métodos
 
 <details open><summary>Public</summary>
@@ -438,6 +411,36 @@ public class DocPackage
 > _No hay métodos private visibles_
 </details>
 
+### 🛠️ Constructores
+
+- `public DocPackage(String name)`
+> **Descripción:**
+> Crea un nuevo descriptor de paquete.
+
+> - *@param* `name` nombre del paquete en notación estándar de Java.
+### 📦 Campos
+
+<details open><summary>Public</summary>
+
+> _No hay campos public visibles_
+</details>
+
+<details open><summary>Protected</summary>
+
+> _No hay campos protected visibles_
+</details>
+
+<details open><summary>Private</summary>
+
+- `private` [String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `name`
+> Nombre completo del paquete (ejemplo: {@code io.github.philbone.javadocmd.exporter}).
+
+- `private` [List](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/List.html)<DocClass> `classes`
+> Conjunto de clases, interfaces, enums y records pertenecientes al paquete.
+
+- `private` [String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `projectName`
+</details>
+
 
 </details>
 <details>
@@ -458,27 +461,6 @@ public enum Kind
 ```java
 public class DocException
 ```
-### 📦 Campos
-
-<details open><summary>Public</summary>
-
-> _No hay campos public visibles_
-</details>
-
-<details open><summary>Protected</summary>
-
-> _No hay campos protected visibles_
-</details>
-
-<details open><summary>Private</summary>
-
-- `private` [String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `name`
-- `private` [String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `description`
-</details>
-
-### 🛠️ Constructores
-
-- `public DocException(String name, String description)`
 ### 🧮 Métodos
 
 <details open><summary>Public</summary>
@@ -497,19 +479,9 @@ public class DocException
 > _No hay métodos private visibles_
 </details>
 
+### 🛠️ Constructores
 
-</details>
-<details>
-<summary> <strong> 📘 Public Class DocField</strong> </summary>
-
-## #8 📘 Public Class DocField
-
-```java
-public class DocField
-```
-> **Descripción:**
-> Representa un campo (atributo) documentado dentro de una clase.
-
+- `public DocException(String name, String description)`
 ### 📦 Campos
 
 <details open><summary>Public</summary>
@@ -525,15 +497,22 @@ public class DocField
 <details open><summary>Private</summary>
 
 - `private` [String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `name`
-- `private` [String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `type`
 - `private` [String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `description`
-- `private` [String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `visibility`
-- `private` boolean `isStatic`
 </details>
 
-### 🛠️ Constructores
 
-- `public DocField(String name, String type, String description, String visibility, boolean isStatic)`
+</details>
+<details>
+<summary> <strong> 📘 Public Class DocField</strong> </summary>
+
+## #8 📘 Public Class DocField
+
+```java
+public class DocField
+```
+> **Descripción:**
+> Representa un campo (atributo) documentado dentro de una clase.
+
 ### 🧮 Métodos
 
 <details open><summary>Public</summary>
@@ -553,6 +532,30 @@ public class DocField
 <details open><summary>Private</summary>
 
 > _No hay métodos private visibles_
+</details>
+
+### 🛠️ Constructores
+
+- `public DocField(String name, String type, String description, String visibility, boolean isStatic)`
+### 📦 Campos
+
+<details open><summary>Public</summary>
+
+> _No hay campos public visibles_
+</details>
+
+<details open><summary>Protected</summary>
+
+> _No hay campos protected visibles_
+</details>
+
+<details open><summary>Private</summary>
+
+- `private` [String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `name`
+- `private` [String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `type`
+- `private` [String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `description`
+- `private` [String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) `visibility`
+- `private` boolean `isStatic`
 </details>
 
 


### PR DESCRIPTION
Este cambio resuelve el problema donde algunos tipos internos (como DocPackage, Config, etc.) no generaban enlaces en la documentación Markdown. Tarea relacionada: #60 – Resolver enlaces internos faltantes en campos de clases.

- Se corrigió la inicialización de InternalLinker en MarkdownExporter, que antes se realizaba dentro del método export(), generando instancias separadas por paquete.
- Ahora InternalLinker se instancia una única vez con el conjunto global de clases del proyecto, asegurando que los tipos internos puedan resolverse correctamente en todos los paquetes.
- Se simplificó el método linkIfInternalType() eliminando código obsoleto de normalización y búsqueda redundante.
- Se mantuvo una coincidencia simple (equals o endsWith) para mejorar confiabilidad y legibilidad.