### PR TITLE
fix(cli): Cambiar Nombre de InstallCommand

### DIFF
--- a/src/main/java/io/github/philbone/javadocmd/cli/AliasCommand.java
+++ b/src/main/java/io/github/philbone/javadocmd/cli/AliasCommand.java
@@ -10,63 +10,63 @@ import java.util.ResourceBundle;
 import java.util.concurrent.Callable;
 
 @Command(
-        name = "install",
-        aliases = {"instalar"},
-        description = "${usage.install}",
+        name = "alias",
+        aliases = {"make-alias"},
+        description = "${usage.alias}",
         mixinStandardHelpOptions = true,
         resourceBundle = "messages"
 )
-public class InstallCommand implements Callable<Integer>
+public class AliasCommand implements Callable<Integer>
 {
     private final ResourceBundle messages;
     private final ConfigurationService configService;
 
-    public InstallCommand() {
+    public AliasCommand() {
         this.messages = ResourceBundle.getBundle("messages");
         this.configService = new ConfigurationService(messages);
     }
     
     @Option(
             names = {"--jar-path", "-p"},
-            descriptionKey = "install.jarPath",
+            descriptionKey = "alias.jarPath",
             defaultValue = "~/.javadocmd"
     )
     private String jarPath;
 
     @Option(
             names = {"--alias-name", "-a"},
-            descriptionKey = "install.aliasName",
+            descriptionKey = "alias.name",
             defaultValue = "javadocmd"
     )
     private String aliasName;
 
     @Option(
             names = {"--force", "-f"},
-            descriptionKey = "install.force"
+            descriptionKey = "alias.force"
     )
     private boolean force;
 
     @Override
     public Integer call() throws Exception {
-        System.out.println(messages.getString("install.message.alias.config"));
+        System.out.println(messages.getString("alias.message.config"));
 
         // Verificar si el alias ya existe
         if (!force && aliasExists(aliasName)) {            
-            System.err.println( String.format(messages.getString("install.message.alias.alreadyExist"), aliasName) ); // ❌ El alias '" + aliasName + "' ya existe en ~/.bashrc
-            System.err.println(messages.getString("install.message.alias.forceTip"));
+            System.err.println( String.format(messages.getString("alias.message.alreadyExist"), aliasName) ); // ❌ El alias '" + aliasName + "' ya existe en ~/.bashrc
+            System.err.println(messages.getString("alias.message.forceTip"));
             return 1;
         }
 
         // Crear el alias
         if (createAlias()) {
-            System.out.println(messages.getString("install.message.alias.success") + ": " + aliasName);
-            System.out.println( String.format(messages.getString("install.message.alias.jarRoute"), jarPath)); //Ruta del JAR: " + jarPath + "/javadocmd-1.0.0.jar
-            System.out.println(messages.getString("install.message.alias.useTip"));
+            System.out.println(messages.getString("alias.message.success") + ": " + aliasName);
+            System.out.println( String.format(messages.getString("alias.message.jarRoute"), jarPath)); //Ruta del JAR: " + jarPath + "/javadocmd-1.0.0.jar
+            System.out.println(messages.getString("alias.message.useTip"));
             System.out.println("   source ~/.bashrc");
             System.out.println("   " + aliasName + " --help");
             return 0;
         } else {
-            System.err.println(messages.getString("install.message.alias.error"));
+            System.err.println(messages.getString("alias.message.error"));
             return 1;
         }
     }
@@ -94,7 +94,7 @@ public class InstallCommand implements Callable<Integer>
             File bashrc = new File(homeDir + "/.bashrc");
 
             FileWriter fw = new FileWriter(bashrc, true);
-            fw.write(messages.getString("install.message.alias.wrout"));
+            fw.write(messages.getString("alias.message.wrout"));
             fw.write("alias " + aliasName + "='java -jar " + jarPath + "/javadocmd-1.0.0.jar'\n");
             fw.close();
 
@@ -106,7 +106,7 @@ public class InstallCommand implements Callable<Integer>
     }
 
 //    public static void main(String[] args) {
-//        int exitCode = new CommandLine(new InstallCommand()).execute(args);
+//        int exitCode = new CommandLine(new AliasCommand()).execute(args);
 //        System.exit(exitCode);
 //    }
 }

--- a/src/main/java/io/github/philbone/javadocmd/cli/JavadocmdCLI.java
+++ b/src/main/java/io/github/philbone/javadocmd/cli/JavadocmdCLI.java
@@ -19,7 +19,7 @@ import java.util.concurrent.Callable;
             GetCommand.class,
             SetCommand.class,
             ValidateCommand.class,
-            InstallCommand.class
+            AliasCommand.class
         }
 )
 public class JavadocmdCLI implements Callable<Integer>

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -31,19 +31,19 @@ usage.helpTip=\ud83d\udca1 Run with --help to see all options
 # Command descriptions (usage.commandName)
 usage.init=Create initial configuration file (config.yml)
 
-usage.install=Create a permanent alias for JavaDocMd to use from the terminal
-install.jarPath=Path to javadocmd.jar (default: ~/.javadocmd)
-install.aliasName=Alias \u200b\u200bname (default: javadocmd)
-install.force=Force creation even if the alias already exists
+usage.alias=Create a permanent alias for JavaDocMd to use from the terminal
+alias.jarPath=Path to javadocmd.jar (default: ~/.javadocmd)
+alias.name=Alias \u200b\u200bname (default: javadocmd)
+alias.force=Force creation even if the alias already exists
 
-install.message.alias.config=\ud83d\ude80 Configuring aliases for JavaDocMd...
-install.message.alias.alreadyExist=\u274c The alias '%s' already exists in ~/.bashrc
-install.message.alias.forceTip=   Use --force to overwrite
-install.message.alias.success=\u2705 Alias \u200b\u200bcreated successfully
-install.message.alias.jarRoute=\ud83d\udcc1 JAR path: %s/javadocmd-1.0.0.jar
-install.message.alias.useTip=\n\ud83d\udcdd To use the alias, run:
-install.message.alias.error=\u274c Error creating alias
-install.message.alias.wrout=\n# Alias \u200b\u200bfor JavaDocMd (created automatically)\n
+alias.message.config=\ud83d\ude80 Configuring aliases for JavaDocMd...
+alias.message.alreadyExist=\u274c The alias '%s' already exists in ~/.bashrc
+alias.message.forceTip=   Use --force to overwrite
+alias.message.success=\u2705 Alias \u200b\u200bcreated successfully
+alias.message.jarRoute=\ud83d\udcc1 JAR path: %s/javadocmd-1.0.0.jar
+alias.message.useTip=\n\ud83d\udcdd To use the alias, run:
+alias.message.error=\u274c Error creating alias
+alias.message.wrout=\n# Alias \u200b\u200bfor JavaDocMd (created automatically)\n
 
 # Usage examples
 usage.example.get=Example: javadocmd get sourcePath
@@ -71,6 +71,7 @@ init.help=Show this help message and exit
 init.interactive=Interactive mode if not all parameters are provided
 init.muteMode=Silent mode creates the necessary directories and files to operate without asking questions.
 
+init.message.configDirCreated=\u2705 Configuration directory created
 init.message.configFileAlreadyExist=\u274c Configuration file already exists
 init.message.configFileAlreadyExist.help=\ud83d\udca1 Use 'validate' to fix or 'set' to modify existing configuration
 init.message.interactiveStart=\ud83d\udca1 Starting interactive configuration...

--- a/src/main/resources/messages_es.properties
+++ b/src/main/resources/messages_es.properties
@@ -31,19 +31,19 @@ usage.helpTip=\ud83d\udca1 Ejecuta con --help para ver todas las opciones
 # Descripciones de comandos (usage.commandName)
 usage.init=Crear archivo de configuraci\u00f3n inicial (config.yml)
 
-usage.install=Crea un alias permanente para JavaDocMd para usar desde la terminal
-install.jarPath=Ruta donde est\u00e1 javadocmd.jar (default: ~/.javadocmd)
-install.aliasName=Nombre del alias (default: javadocmd)
-install.force=Forzar creaci\u00f3n aunque el alias ya exista
+usage.alias=Crea un alias permanente para JavaDocMd para usar desde la terminal
+alias.jarPath=Ruta donde est\u00e1 javadocmd.jar (default: ~/.javadocmd)
+alias.name=Nombre del alias (default: javadocmd)
+alias.force=Forzar creaci\u00f3n aunque el alias ya exista
 
-install.message.alias.config=\ud83d\ude80 Configurando alias para JavaDocMd...
-install.message.alias.alreadyExist=\u274c El alias '%s' ya existe en ~/.bashrc
-install.message.alias.forceTip=   Usa --force para sobrescribir
-install.message.alias.success=\u2705 Alias creado exitosamente
-install.message.alias.jarRoute=\ud83d\udcc1 Ruta del JAR: %s/javadocmd-1.0.0.jar
-install.message.alias.useTip=\n\ud83d\udcdd Para usar el alias ejecuta:
-install.message.alias.error=\u274c Error al crear el alias
-install.message.alias.wrout=\n# Alias para JavaDocMd (creado autom\u00e1ticamente)\n
+alias.message.config=\ud83d\ude80 Configurando alias para JavaDocMd...
+alias.message.alreadyExist=\u274c El alias '%s' ya existe en ~/.bashrc
+alias.message.forceTip=   Usa --force para sobrescribir
+alias.message.success=\u2705 Alias creado exitosamente
+alias.message.jarRoute=\ud83d\udcc1 Ruta del JAR: %s/javadocmd-1.0.0.jar
+alias.message.useTip=\n\ud83d\udcdd Para usar el alias ejecuta:
+alias.message.error=\u274c Error al crear el alias
+alias.message.wrout=\n# Alias para JavaDocMd (creado autom\u00e1ticamente)\n
 
 # Ejemplos de uso
 usage.example.get=Ejemplo: javadocmd get sourcePath
@@ -71,6 +71,7 @@ init.help=Mostrar esta ayuda y salir
 init.interactive=Modo interactivo si no se proporcionan todos los par\u00e1metros
 init.muteMode=Modo silencioso, crea los directorios y ficheros necesarios para funcionar sin hacer preguntas.
 
+init.message.configDirCreated=\u2705 Directorio de configuraci\u00f3n creado
 init.message.configFileAlreadyExist=\u274c El archivo de configuraci\u00f3n ya existe
 init.message.configFileAlreadyExist.help=\ud83d\udca1 Usa 'validate' para corregir o 'set' para modificar la configuraci\u00f3n existente
 init.message.interactiveStart=\ud83d\udca1 Iniciando configuraci\u00f3n interactiva...


### PR DESCRIPTION
- Modifica la clase InstallCommand → AliasCommand.
- Modificar JavadocmdCLI.java: InstallCommand.class → AliasCommand.class.
- Cambia alias instalar → make-alias.
- Modifica la internacionalización del comando AliasCommand.
- Edita todas las ocurrencias de install en message.properties y message_es.properties,